### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Availability of the following entities and services varies across cores.
 ### 1. Entities
 
 - Proxy group sensor (all, current latency attributes)
-- Proxy gorup selector (all, current latency attributes)
+- Proxy group selector (all, current latency attributes)
 - Traffic sensor (up/down)
 - Total traffic sensor (up/down)
 - Connection number sensor


### PR DESCRIPTION
## Summary
- correct 'Proxy gorup selector' typo in README

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684a8a2a708c832b86f12619ba547ba8