### PR TITLE
Streamline README usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ Core support:
 | Clash Premium   | Partially | 2023.08.17     | End of life |
 | Clash Meta      | Partially | v1.16.0        | Legacy predecessor of Mihomo |
 | Mihomo          | Yes       | v1.19.28       | Actively maintained |
-
-These versions are exercised against real core binaries in CI. The binaries are
-downloaded into a local cache, verified by SHA-256, and are not committed to this
-repository. See [the core compatibility test documentation](tests/core_compatibility/README.md)
-for provenance and local test commands.
-
 ## Installation
 
 Home Assistant Core must be `2024.4.3` or newer. 
@@ -67,159 +61,21 @@ Core capability is automatically detected at entry load, and unsupported entitie
 
 ### 1. Entities
 
-- Proxy group sensor (all, current latency attributes)
-- Proxy group selector (all, current latency attributes)
-- Traffic sensor (up/down)
-- Total traffic sensor (up/down)
-- Connection number sensor
-- Memory info sensor
-- Provider count sensors
-- Flush FakeIP cache button
-- Flush DNS cache button
-- Proxy provider healthcheck buttons
-- Proxy mode selector
+- Proxy group and mode selectors
+- Traffic, connection and memory sensors
+- Provider counters and health-check buttons
+- DNS and FakeIP cache flush buttons
 
 ### 2. Services
 
-<table>
-  <tr>
-    <th>Service Name</th>
-    <th>Parameter</th>
-    <th>Required</th>
-    <th>Description</th>
-  </tr>
-  
-  <tr>
-    <td align="center"><b>Reboot Clash Core</b></td>
-    <td><code>device_id</code></td>
-    <td>✅ Yes</td>
-    <td>Select the target instance to reboot the Clash core.</td>
-  </tr>
-  <tr>
-    <td rowspan="5" align="center"><b>Filter Connection</b></td>
-    <td><code>device_id</code></td>
-    <td>✅ Yes</td>
-    <td>Select the target instance.</td>
-  </tr>
-  <tr>
-    <td><code>close_connection</code></td>
-    <td>❌ No</td>
-    <td>If enabled, retrieved connections will also be closed.</td>
-  </tr>
-  <tr>
-    <td><code>host</code></td>
-    <td>❌ No</td>
-    <td>Filter connections by host.</td>
-  </tr>
-  <tr>
-    <td><code>src_hostname</code></td>
-    <td>❌ No</td>
-    <td>Filter connections by source hostname.</td>
-  </tr>
-  <tr>
-    <td><code>des_hostname</code></td>
-    <td>❌ No</td>
-    <td>Filter connections by destination hostname.</td>
-  </tr>
-
-  <tr>
-    <td rowspan="5" align="center"><b>Get Latency</b></td>
-    <td><code>device_id</code></td>
-    <td>✅ Yes</td>
-    <td>Select the target instance.</td>
-  </tr>
-  <tr>
-    <td><code>group</code></td>
-    <td>❌ No</td>
-    <td>Proxy group name. Testing a group will also clear its fixed option if set.</td>
-  </tr>
-  <tr>
-    <td><code>node</code></td>
-    <td>❌ No</td>
-    <td>Proxy node name.</td>
-  </tr>
-  <tr>
-    <td><code>url</code></td>
-    <td>❌ No</td>
-    <td>The URL used to test the latency.</td>
-  </tr>
-  <tr>
-    <td><code>timeout</code></td>
-    <td>❌ No</td>
-    <td>Connection timeout in milliseconds.</td>
-  </tr>
-
-  <tr>
-    <td rowspan="3" align="center"><b>DNS Query</b></td>
-    <td><code>device_id</code></td>
-    <td>✅ Yes</td>
-    <td>Select the target instance.</td>
-  </tr>
-  <tr>
-    <td><code>domain_name</code></td>
-    <td>✅ Yes</td>
-    <td>The domain name to query.</td>
-  </tr>
-  <tr>
-    <td><code>record_type</code></td>
-    <td>❌ No</td>
-    <td>The record type to query. Leave empty to get IPv4 (A) record.</td>
-  </tr>
-
-  <tr>
-    <td rowspan="4" align="center"><b>Get Rule</b></td>
-    <td><code>device_id</code></td>
-    <td>✅ Yes</td>
-    <td>Select the target instance.</td>
-  </tr>
-  <tr>
-    <td><code>rule_type</code></td>
-    <td>❌ No</td>
-    <td>The type of the rule.</td>
-  </tr>
-  <tr>
-    <td><code>rule_payload</code></td>
-    <td>❌ No</td>
-    <td>The payload to match.</td>
-  </tr>
-  <tr>
-    <td><code>rule_proxy</code></td>
-    <td>❌ No</td>
-    <td>The proxy method used.</td>
-  </tr>
-
-  <tr>
-    <td rowspan="6" align="center"><b>API Call</b></td>
-    <td><code>device_id</code></td>
-    <td>✅ Yes</td>
-    <td>Select the target instance.</td>
-  </tr>
-  <tr>
-    <td><code>api_endpoint</code></td>
-    <td>✅ Yes</td>
-    <td>The API endpoint to be used.</td>
-  </tr>
-  <tr>
-    <td><code>api_method</code></td>
-    <td>✅ Yes</td>
-    <td>The HTTP method (GET, POST, etc.).</td>
-  </tr>
-  <tr>
-    <td><code>api_params</code></td>
-    <td>❌ No</td>
-    <td>The query parameters for the request. Needs to be a valid JSON string.</td>
-  </tr>
-  <tr>
-    <td><code>api_data</code></td>
-    <td>❌ No</td>
-    <td>The JSON body sent in the request. Needs to be a valid JSON string.</td>
-  </tr>
-  <tr>
-    <td><code>read_line</code></td>
-    <td>❌ No</td>
-    <td>Indicates to read the n-th line for a chunked response.</td>
-  </tr>
-</table>
+| Action | Description |
+|--------|-------------|
+| `reboot_core_service` | Reboot the selected Clash core. |
+| `filter_connection_service` | Find active connections and optionally close them. |
+| `get_latency_service` | Test the latency of a proxy group or node. |
+| `dns_query_service` | Query a DNS record through the selected core. |
+| `get_rule_service` | Find rules by type, payload or proxy. |
+| `api_call_service` | Call any Clash-compatible API endpoint. |
 
 
 Example call of getting available proxies:


### PR DESCRIPTION
## What changed

- Replace the long action parameter table with a six-row action summary.
- Group related entities by category.
- Remove implementation details below the core compatibility table.

## Why

The README duplicated metadata already exposed by Home Assistant and made the main project page unnecessarily long. This keeps the user-facing overview concise while preserving the useful API call example.

## Validation

- Resolved the README conflict against the current `main` branch.
- Rebasing completed successfully.
- `git diff --check` passes.
