### PR TITLE
重构：实现 runtime_data、支持 Reconfigure，并提供稳定的 Unique ID

### DIFF
--- a/custom_components/clash_controller/__init__.py
+++ b/custom_components/clash_controller/__init__.py
@@ -2,108 +2,102 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.device_registry import DeviceEntry
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers import entity_registry as er
 
-from .const import DOMAIN
+from .const import DOMAIN, PLATFORMS, CONF_API_URL, CONF_BEAR_TOKEN, CONF_ALLOW_UNSAFE
+from .api import ClashAPI
 from .coordinator import ClashControllerCoordinator
-from .services import ClashServicesSetup
+from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [
-    Platform.SENSOR,
-    Platform.SELECT,
-    Platform.BUTTON,
-]
-
 @dataclass
-class RuntimeData:
+class ClashRuntimeData:
     """Class to hold integration data."""
+    coordinator: ClashControllerCoordinator
+    api: ClashAPI
 
-    coordinator: DataUpdateCoordinator
-    cancel_update_listener: Callable
-    setup_done: bool = False
+type ClashConfigEntry = ConfigEntry[ClashRuntimeData]
 
-
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ClashConfigEntry) -> bool:
     """Set up Clash Controller from a config entry."""
 
-    hass.data.setdefault(DOMAIN, {})
-    runtime_data: RuntimeData | None = hass.data[DOMAIN].get(config_entry.entry_id)
-    setup_done = runtime_data.setup_done if runtime_data else False
-    coordinator = ClashControllerCoordinator(hass, config_entry)
+    api = ClashAPI(
+        hass,
+        host=entry.data[CONF_API_URL],
+        token=entry.data[CONF_BEAR_TOKEN],
+        entry_id=entry.entry_id,
+        allow_unsafe=entry.data.get(CONF_ALLOW_UNSAFE, False),
+        available_endpoints=entry.data.get("available_endpoints"),
+        capabilities=entry.data.get("capabilities"),
+    )
 
+    coordinator = ClashControllerCoordinator(hass, entry)
+    coordinator.api = api
+    await _async_migrate_unique_ids(hass, entry)
     try:
         await coordinator.async_config_entry_first_refresh()
     except ConfigEntryNotReady as err:
-        if not setup_done:
+        if entry.data.get("available_endpoints"):
+            _LOGGER.warning("Clash 暂时无法连接，使用缓存模式启动: %s", err)
+        else:
             raise err
-        _LOGGER.warning(err)
-        coordinator.data = coordinator.data or []
 
     if coordinator.last_update_success:
         capabilities = coordinator.api.capabilities or {}
-        available_endpoints = coordinator.api.available_endpoints or []
-        normalized_endpoints = [list(item) for item in available_endpoints]
+        available_endpoints = [list(item) for item in (coordinator.api.available_endpoints or [])]
         if (
-            config_entry.data.get("capabilities") != capabilities
-            or config_entry.data.get("available_endpoints") != normalized_endpoints
+            entry.data.get("capabilities") != capabilities
+            or entry.data.get("available_endpoints") != available_endpoints
         ):
             hass.config_entries.async_update_entry(
-                config_entry,
+                entry,
                 data={
-                    **config_entry.data,
-                    "available_endpoints": normalized_endpoints,
+                    **entry.data,
+                    "available_endpoints": available_endpoints,
                     "capabilities": capabilities,
                 },
             )
 
-    cancel_update_listener = config_entry.add_update_listener(_async_update_listener)
-    hass.data[DOMAIN][config_entry.entry_id] = RuntimeData(
-        coordinator, cancel_update_listener, True
-    )
-    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-    ClashServicesSetup(hass)
+    entry.runtime_data = ClashRuntimeData(coordinator=coordinator, api=api)
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await async_setup_services(hass)
     return True
 
+async def _async_migrate_unique_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """将旧实体的 Unique ID 从基于 IP 的格式迁移到基于 Entry ID 的格式。"""
+    ent_reg = er.async_get(hass)
+    existing_entries = er.async_entries_for_config_entry(ent_reg, entry.entry_id)
+    for entity_entry in existing_entries:
+        old_uid = entity_entry.unique_id
+        if not old_uid.startswith(entry.entry_id):
+            parts = old_uid.split("_")
+            new_uid = f"{entry.entry_id}_{'_'.join(parts[-2:])}"
+            _LOGGER.debug("Migrating unique_id from [%s] to [%s]", old_uid, new_uid)
+            try:
+                ent_reg.async_update_entity(entity_entry.entity_id, new_unique_id=new_uid)
+            except ValueError:
+                _LOGGER.warning("Could not migrate unique_id for %s, new ID already exists", entity_entry.entity_id)
 
-async def _async_update_listener(hass: HomeAssistant, config_entry):
-    """Handle config options update."""
+async def _async_update_listener(hass: HomeAssistant, entry: ClashConfigEntry):
+    """处理选项流更新。"""
+    await hass.config_entries.async_reload(entry.entry_id)
 
-    await hass.config_entries.async_reload(config_entry.entry_id)
+async def async_unload_entry(hass: HomeAssistant, entry: ClashConfigEntry) -> bool:
+    """卸载配置条目。"""
 
-
-async def async_remove_config_entry_device(
-    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry) -> bool:
-    """Handle entry removal."""
-
-    return True
-
-
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
-
-    runtime_data = hass.data[DOMAIN][config_entry.entry_id]
-    runtime_data.cancel_update_listener()
-    coordinator = runtime_data.coordinator
-    if coordinator:
-        await coordinator.api.close_session()
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        config_entry, PLATFORMS
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(config_entry.entry_id)
-        if not hass.data[DOMAIN]:
+
+        if not hass.config_entries.async_entries(DOMAIN):
             for service in list(hass.services.async_services_for_domain(DOMAIN)):
                 hass.services.async_remove(DOMAIN, service)
-            hass.data.pop(DOMAIN)
+                
     return unload_ok

--- a/custom_components/clash_controller/api.py
+++ b/custom_components/clash_controller/api.py
@@ -12,6 +12,7 @@ import ssl
 import time
 
 import aiohttp
+from homeassistant.helpers.aiohttp_client import async_get_clientsession, async_create_clientsession
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +30,6 @@ SERVICE_TABLE = {
     },
 }
 
-
 class ClashAPI:
     """A utility class to interact with the Clash API."""
 
@@ -38,8 +38,10 @@ class ClashAPI:
 
     def __init__(
         self,
+        hass: HomeAssistant,
         host: str,
         token: str,
+        entry_id: str,
         allow_unsafe: bool = False,
         available_endpoints: Optional[list[tuple[str, dict[str, Any]]]] = None,
         capabilities: Optional[dict[str, bool]] = None,
@@ -48,18 +50,15 @@ class ClashAPI:
         self.host = host
         self.token = token
         self.allow_unsafe = allow_unsafe
-        self.device_id = (
-            re.sub(r"[^a-zA-Z0-9]", "_", self.host.strip().lower().rstrip("_"))
-            + "_device"
-        )
-        self._session: Optional[aiohttp.ClientSession] = None
-        self._status_session: Optional[aiohttp.ClientSession] = None
-        self._available_endpoints: Optional[list[tuple[str, dict[str, Any]]]] = (
-            available_endpoints
-        )
-        self._capabilities: Optional[dict[str, bool]] = (
-            dict(capabilities) if capabilities else None
-        )
+        self.device_id = entry_id 
+        if allow_unsafe:
+            self._session = async_create_clientsession(hass, verify_ssl=False)
+        else:
+            self._session = async_get_clientsession(hass)
+            
+        self._status_session = async_get_clientsession(hass)
+        self._available_endpoints = available_endpoints
+        self._capabilities = dict(capabilities) if capabilities else None
 
     @property
     def available_endpoints(self) -> Optional[list[tuple[str, dict[str, Any]]]]:
@@ -139,14 +138,16 @@ class ClashAPI:
             if read_line < 1:
                 return await response.json()
             line_counter = 0
-            async for line in response.content:
-                line_counter += 1
-                if line_counter == read_line:
-                    return json.loads(line.decode("utf-8").strip())
+            try:
+                async with asyncio.timeout(3.0):
+                    async for line in response.content:
+                        line_counter += 1
+                        if line_counter == read_line:
+                            return json.loads(line.decode("utf-8").strip())
+            except (asyncio.TimeoutError, TimeoutError):
+                _LOGGER.debug("端点 %s 读取超时（Clash 暂无流量），跳过采样", endpoint)
+                return None
             return None
-
-        if self._session is None:
-            await self._establish_session()
 
         url = f"{self.host}{endpoint}"
         _LOGGER.debug("Making %s request to %s, read line: %s.", method, url, read_line)
@@ -158,6 +159,7 @@ class ClashAPI:
                 params=params,
                 json=json_data,
                 headers=self._request_headers(),
+                timeout=aiohttp.ClientTimeout(total=10),
             ) as response:
                 response.raise_for_status()
                 try:
@@ -173,13 +175,10 @@ class ClashAPI:
                 raise APIAuthError("Invalid API credentials.") from err
             raise APIClientError(f"API request got an invalid response: {err}") from err
         except asyncio.TimeoutError as err:
-            await self.close_session()
             raise APITimeoutError(f"API request timed out: {err}") from err
         except aiohttp.ClientConnectionError as err:
-            await self.close_session()
             raise APIConnectionError(f"API request connection error: {err}") from err
         except Exception as err:
-            await self.close_session()
             raise APIClientError(f"API request generic failure: {err}") from err
 
     async def async_ws_request(
@@ -198,22 +197,23 @@ class ClashAPI:
         if client_ws_timeout is not None:
             ws_timeout = client_ws_timeout(ws_receive=timeout, ws_close=timeout)
         try:
-            async with self._session.ws_connect(
-                ws_url,
-                headers=self._ws_headers(),
-                heartbeat=30,
-                timeout=ws_timeout,
-            ) as websocket:
-                message = await websocket.receive(timeout=timeout)
-                if message.type == aiohttp.WSMsgType.TEXT:
-                    payload = json.loads(message.data.strip())
-                    return payload if isinstance(payload, dict) else {}
-                if message.type == aiohttp.WSMsgType.BINARY:
-                    payload = json.loads(message.data.decode("utf-8").strip())
-                    return payload if isinstance(payload, dict) else {}
-                raise APIClientError(
-                    f"Unexpected websocket message type for {endpoint}: {message.type}"
-                )
+            async with asyncio.timeout(5.0):
+                async with self._session.ws_connect(
+                    ws_url,
+                    headers=self._ws_headers(),
+                    heartbeat=30,
+                    timeout=ws_timeout,
+                ) as websocket:
+                    message = await websocket.receive(timeout=timeout)
+                    if message.type == aiohttp.WSMsgType.TEXT:
+                        payload = json.loads(message.data.strip())
+                        return payload if isinstance(payload, dict) else {}
+                    if message.type == aiohttp.WSMsgType.BINARY:
+                        payload = json.loads(message.data.decode("utf-8").strip())
+                        return payload if isinstance(payload, dict) else {}
+                    raise APIClientError(
+                        f"Unexpected websocket message type for {endpoint}: {message.type}"
+                    )
         except Exception:
             if suppress_errors:
                 return {}
@@ -722,18 +722,18 @@ class ClashAPI:
 
         return data
 
+    async def close_session(self):
+        """Session is now managed by Home Assistant core."""
+        pass
 
 class APIAuthError(Exception):
     """Exception class for auth error."""
 
-
 class APIClientError(Exception):
     """Exception class for generic client error."""
 
-
 class APITimeoutError(Exception):
     """Exception class for timeout error."""
-
 
 class APIConnectionError(Exception):
     """Exception class for connection error."""

--- a/custom_components/clash_controller/base.py
+++ b/custom_components/clash_controller/base.py
@@ -1,14 +1,15 @@
 """Base entity for Clash Controller."""
 
+from __future__ import annotations
 import logging
-
+from typing import TYPE_CHECKING
 from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .coordinator import ClashControllerCoordinator, ClashEntityData
+if TYPE_CHECKING:
+    from .coordinator import ClashControllerCoordinator, ClashEntityData
 
 _LOGGER = logging.getLogger(__name__)
-
 
 class BaseEntity(CoordinatorEntity):
     """Base entity class."""
@@ -66,4 +67,3 @@ class BaseEntity(CoordinatorEntity):
     def translation_key(self):
         """Return translation key with backward-compatible behavior."""
         return self.entity_data.translation_key
-

--- a/custom_components/clash_controller/button.py
+++ b/custom_components/clash_controller/button.py
@@ -1,56 +1,100 @@
 """Button platform for Clash Controller."""
 
-import logging
+from __future__ import annotations
 
-from homeassistant.components.button import ButtonEntity
-from homeassistant.config_entries import ConfigEntry
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base import BaseEntity
-from .const import DOMAIN
-from .coordinator import ClashControllerCoordinator, ClashEntityData
+
+if TYPE_CHECKING:
+    from . import ClashConfigEntry
+    from .coordinator import ClashControllerCoordinator, ClashEntityData
 
 _LOGGER = logging.getLogger(__name__)
 
+@dataclass(frozen=True, kw_only=True)
+class ClashButtonEntityDescription(ButtonEntityDescription):
+    """描述 Clash 按钮的自定义类。"""
+
+# 静态描述符配置
+BUTTON_DESCRIPTIONS: Final[dict[str, ClashButtonEntityDescription]] = {
+    "fakeip_flush_button": ClashButtonEntityDescription(
+        key="fakeip_flush_button",
+        translation_key="flush_cache",
+        icon="mdi:cached",
+    ),
+    "dns_flush_button": ClashButtonEntityDescription(
+        key="dns_flush_button",
+        translation_key="flush_dns_cache",
+        icon="mdi:cached",
+    ),
+}
+
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    entry: ClashConfigEntry, 
     async_add_entities: AddEntitiesCallback,
-):
+) -> None:
+    """基于 Config Entry 设置按钮平台。"""
+    
+    coordinator = entry.runtime_data.coordinator
 
-    coordinator: ClashControllerCoordinator = hass.data[DOMAIN][config_entry.entry_id].coordinator
+    entities: list[ClashButtonEntity] = []
 
-    button_types = {
-        "fakeip_flush_button": ButtonEntityBase,
-        "dns_flush_button": ButtonEntityBase,
-        "provider_healthcheck_button": ButtonEntityBase,
-    }
+    for entity_data in coordinator.data:
+        if entity_data.entity_type in [
+            "fakeip_flush_button", 
+            "dns_flush_button", 
+            "provider_healthcheck_button"
+        ]:
+            # 获取或动态创建描述符
+            description = BUTTON_DESCRIPTIONS.get(entity_data.entity_type)
+            if not description:
+                description = ClashButtonEntityDescription(
+                    key=entity_data.unique_key or entity_data.entity_type,
+                    translation_key=entity_data.translation_key,
+                    icon=entity_data.icon,
+                )
 
-    buttons = [
-        button_types[entity_type](coordinator, entity_data)
-        for entity_data in coordinator.data
-        if (entity_type := entity_data.entity_type) in button_types
-    ]
+            entities.append(ClashButtonEntity(coordinator, entity_data, description))
 
-    async_add_entities(buttons)
+    async_add_entities(entities)
 
-class ButtonEntityBase(BaseEntity, ButtonEntity):
-    """Base button entity class."""
+class ClashButtonEntity(BaseEntity, ButtonEntity):
+    """按钮实体类"""
+
+    entity_description: ClashButtonEntityDescription
 
     def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
+        self, 
+        coordinator: ClashControllerCoordinator, 
+        entity_data: ClashEntityData,
+        description: ClashButtonEntityDescription
     ) -> None:
+        """初始化按钮。"""
+
+        self.entity_description = description
         super().__init__(coordinator, entity_data)
 
     async def async_press(self) -> None:
-        """Press action."""
         action = self.entity_data.action or {}
         method = action.get("method")
         args = action.get("args", [])
         kwargs = action.get("kwargs", {})
+        
         if method is None:
             raise HomeAssistantError("No action defined for this button.")
-        await method(*args, **kwargs)
-        self.async_write_ha_state()
+            
+        try:
+            await method(*args, **kwargs)
+            self.async_write_ha_state()
+        except Exception as err:
+            _LOGGER.error("Error executing button action: %s", err)
+            raise HomeAssistantError(f"Action failed: {err}") from err

--- a/custom_components/clash_controller/config_flow.py
+++ b/custom_components/clash_controller/config_flow.py
@@ -7,6 +7,7 @@ import re
 from typing import Any
 
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant.config_entries import (
     ConfigEntry,
@@ -19,10 +20,10 @@ from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
 from .api import (
-    APITimeoutError,
     APIAuthError,
-    APIClientError,
     APIConnectionError,
+    APIClientError,
+    APITimeoutError,
     ClashAPI,
 )
 from .const import (
@@ -42,21 +43,10 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-async def _test_connection(api: ClashAPI):
-    errors = {}
-    try:
-        await api.connected(suppress_errors=False)
-    except APIAuthError:
-        errors["base"] = "invalid_token"
-    except APITimeoutError:
-        errors["base"] = "timed_out"
-    except (APIClientError, APIConnectionError):
-        errors["base"] = "cannot_connect"
-    except Exception:
-        errors["base"] = "unknown"
-    return errors
 class ClashControllerConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Clash Controller."""
+    """处理 Clash 控制器的配置流。"""
+
+    VERSION = 1
 
     def _normalize_url(self, api_url: str, use_ssl: bool):
         if api_url.startswith("http://") or api_url.startswith("https://"):
@@ -69,115 +59,129 @@ class ClashControllerConfigFlow(ConfigFlow, domain=DOMAIN):
         if not api_url.endswith('/'):
             api_url += '/'
         return api_url
-    
-    async def _set_unique_id(self, api_url: str):
-        unique_id = re.sub(r"[^a-zA-Z0-9]", "_", api_url.strip().lower().rstrip("_"))
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
-        return unique_id
+
+    async def _test_connection(self, api: ClashAPI) -> dict[str, str]:
+        """公用的连接测试逻辑。"""
+        errors = {}
+        try:
+            if not await api.connected(suppress_errors=False):
+                errors["base"] = "cannot_connect"
+        except APIAuthError:
+            errors["base"] = "invalid_token"
+        except APITimeoutError:
+            errors["base"] = "timed_out"
+        except (APIClientError, APIConnectionError):
+            errors["base"] = "cannot_connect"
+        except Exception:
+            _LOGGER.exception("Unexpected error testing Clash connection")
+            errors["base"] = "unknown"
+        return errors
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Handle the initial (and only) step."""
+        """处理初始配置步骤。"""
+        errors: dict[str, str] = {}
 
-        errors = {}
-
-        if user_input is None:
-            user_input = {}
-
-        api_url = user_input.get(CONF_API_URL, "")
-        token = user_input.get(CONF_BEAR_TOKEN, "")
-        use_ssl = user_input.get(CONF_USE_SSL, False)
-        allow_unsafe = user_input.get(CONF_ALLOW_UNSAFE, False)
-
-        if user_input:
-
-            api_url = self._normalize_url(api_url, use_ssl)
+        if user_input is not None:
+            api_url = self._normalize_url(user_input[CONF_API_URL], user_input.get(CONF_USE_SSL, False))
             user_input[CONF_API_URL] = api_url
-            api = ClashAPI(api_url, token, allow_unsafe)
+            unique_id = re.sub(r"[^a-zA-Z0-9]", "_", api_url)
+            await self.async_set_unique_id(unique_id)
+            self._abort_if_unique_id_configured()
+            api = ClashAPI(
+                self.hass,
+                api_url,
+                user_input[CONF_BEAR_TOKEN],
+                unique_id,
+                user_input.get(CONF_ALLOW_UNSAFE, False)
+            )
+            errors = await self._test_connection(api)
+            if not errors:
+                return self.async_create_entry(title=f"Clash ({URL(api_url).host})", data=user_input)
 
-            await self._set_unique_id(api_url)
-
-            errors = await _test_connection(api)
-            if "base" not in errors:
-                user_input["capabilities"] = {}
-                user_input["available_endpoints"] = []
-                await api.close_session()
-                return self.async_create_entry(title=api_url, data=user_input)
-            await api.close_session()
+        # 定义表单 Schema
+        data_schema = vol.Schema({
+            vol.Required(CONF_API_URL): cv.string,
+            vol.Required(CONF_BEAR_TOKEN): cv.string,
+            vol.Optional(CONF_USE_SSL, default=False): cv.boolean,
+            vol.Optional(CONF_ALLOW_UNSAFE, default=False): cv.boolean,
+        })
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({
-                vol.Required(CONF_API_URL, default=api_url): cv.string,
-                vol.Required(CONF_BEAR_TOKEN, default=token): cv.string,
-                vol.Optional(CONF_USE_SSL, default=use_ssl): cv.boolean,
-                vol.Optional(CONF_ALLOW_UNSAFE, default=allow_unsafe): cv.boolean,
-            }),
+            data_schema=self.add_suggested_values_to_schema(data_schema, user_input),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """处理重新配置流程。"""
+
+        entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            api_url = self._normalize_url(user_input[CONF_API_URL], user_input.get(CONF_USE_SSL, False))
+            api = ClashAPI(
+                self.hass,
+                api_url,
+                user_input[CONF_BEAR_TOKEN],
+                entry.entry_id,
+                user_input.get(CONF_ALLOW_UNSAFE, False)
+            )
+            errors = await self._test_connection(api)
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    entry, 
+                    data={**entry.data, **user_input, CONF_API_URL: api_url}
+                )
+
+        # 预填当前数据
+        data_schema = vol.Schema({
+            vol.Required(CONF_API_URL): cv.string,
+            vol.Required(CONF_BEAR_TOKEN): cv.string,
+            vol.Optional(CONF_USE_SSL): cv.boolean,
+            vol.Optional(CONF_ALLOW_UNSAFE): cv.boolean,
+        })
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(data_schema, user_input or entry.data),
             errors=errors,
         )
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
-        """Return the options flow handler."""
-        return ClashControllerOptionsFlow(config_entry)
+    def async_get_options_flow(config_entry: ConfigEntry) -> ClashControllerOptionsFlow:
+        """开启选项流处理器。"""
+        return ClashControllerOptionsFlow()
 
 class ClashControllerOptionsFlow(OptionsFlow):
-    """Handle options for Clash Controller."""
+    """处理 Clash 的运行时选项更新。"""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.entry_id = config_entry.entry_id
-        self.options = dict(config_entry.options)
-        
-    async def async_step_init(self, user_input=None):
-        """Handle options flow."""
-
-        errors = {}
-        config_entry = self.hass.config_entries.async_get_entry(self.entry_id)
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """选项设置主步骤。"""
 
         if user_input is not None:
-            token = user_input.get(CONF_BEAR_TOKEN)
+                return self.async_create_entry(title="", data=user_input)
 
-            if token:
-                api_url = config_entry.data[CONF_API_URL]
-                allow_unsafe = config_entry.data.get(CONF_ALLOW_UNSAFE, False)
-                api = ClashAPI(api_url, token, allow_unsafe)
-                errors = await _test_connection(api)
-                await api.close_session()
-
-            if errors.get("base") != "invalid_token":
-                options = dict(config_entry.options)
-                options[CONF_SCAN_INTERVAL] = user_input[CONF_SCAN_INTERVAL]
-                options[CONF_CONCURRENT_CONNECTIONS] = user_input[CONF_CONCURRENT_CONNECTIONS]
-                options[CONF_STREAMING_DETECTION] = user_input[CONF_STREAMING_DETECTION]
-
-                if token:
-                    data = dict(config_entry.data)
-                    data[CONF_BEAR_TOKEN] = token
-                    self.hass.config_entries.async_update_entry(config_entry, data=data)
-
-                return self.async_create_entry(title="", data=options)
+        options_schema = vol.Schema({
+            vol.Required(
+                CONF_SCAN_INTERVAL,
+                default=self.config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+            ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_SCAN_INTERVAL)),
+            
+            vol.Required(
+                CONF_CONCURRENT_CONNECTIONS,
+                default=self.config_entry.options.get(CONF_CONCURRENT_CONNECTIONS, DEFAULT_CONCURRENT_CONNECTIONS),
+            ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_CONCURRENT_CONNECTIONS)),
+            
+            vol.Optional(
+                CONF_STREAMING_DETECTION,
+                default=self.config_entry.options.get(CONF_STREAMING_DETECTION, DEFAULT_STREAMING_DETECTION)
+            ): cv.boolean,
+        })
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema({
-                vol.Required(
-                    CONF_SCAN_INTERVAL,
-                    default=self.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
-                ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_SCAN_INTERVAL)),
-                vol.Required(
-                    CONF_CONCURRENT_CONNECTIONS,
-                    default=self.options.get(CONF_CONCURRENT_CONNECTIONS, DEFAULT_CONCURRENT_CONNECTIONS),
-                ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_CONCURRENT_CONNECTIONS)),
-                vol.Optional(
-                    CONF_BEAR_TOKEN,
-                    default=""
-                ): cv.string,
-                vol.Optional(
-                    CONF_STREAMING_DETECTION,
-                    default=self.options.get(CONF_STREAMING_DETECTION, DEFAULT_STREAMING_DETECTION)
-                ): cv.boolean,
-            }),
-            errors=errors,
+            data_schema=self.add_suggested_values_to_schema(
+                options_schema, user_input
+            ),
         )

--- a/custom_components/clash_controller/const.py
+++ b/custom_components/clash_controller/const.py
@@ -1,28 +1,32 @@
 """Constants for the Clash Controller."""
+from __future__ import annotations
+
+from homeassistant.const import Platform
 
 DOMAIN = "clash_controller"
 
-# Configs
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.SELECT,
+    Platform.BUTTON,
+]
 
+# Configs
 CONF_API_URL = "api_url"
 CONF_BEAR_TOKEN = "bearer_token"
 CONF_USE_SSL = "use_ssl"
 CONF_ALLOW_UNSAFE = "allow_unsafe"
 
 # Options
-
 MIN_SCAN_INTERVAL = 10
 DEFAULT_SCAN_INTERVAL = 60
-
 MIN_CONCURRENT_CONNECTIONS = 1
 DEFAULT_CONCURRENT_CONNECTIONS = 5
 CONF_CONCURRENT_CONNECTIONS = "concurrent_connections"
-
 CONF_STREAMING_DETECTION = "streaming_detection"
 DEFAULT_STREAMING_DETECTION = False
 
 # Service names
-
 API_CALL_SERVICE_NAME = "api_call_service"
 DNS_QUERY_SERVICE_NAME = "dns_query_service"
 FILTER_CONNECTION_SERVICE_NAME = "filter_connection_service"

--- a/custom_components/clash_controller/coordinator.py
+++ b/custom_components/clash_controller/coordinator.py
@@ -40,11 +40,9 @@ CORE_DATA_KEYS = frozenset(
     }
 )
 
-
 @dataclass(slots=True)
 class ClashEntityData:
     """Structured data model used by entities."""
-
     name: str | None
     entity_type: str
     state: Any = None
@@ -59,7 +57,6 @@ class ClashEntityData:
     unique_key: str | None = None
     unique_id: str = ""
 
-
 class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
     """A coordinator to fetch data from the Clash API."""
 
@@ -71,6 +68,7 @@ class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
         self.token = config_entry.data["bearer_token"]
         self.allow_unsafe = config_entry.data["allow_unsafe"]
         self.config_entry = config_entry
+        self.entry_id = config_entry.entry_id
 
         self.poll_interval = config_entry.options.get(
             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
@@ -99,8 +97,10 @@ class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
             dict(stored_capabilities) if isinstance(stored_capabilities, dict) else None
         )
         self.api = ClashAPI(
+            hass,
             host=self.host,
             token=self.token,
+            entry_id=self.entry_id,
             allow_unsafe=self.allow_unsafe,
             available_endpoints=available_endpoints,
             capabilities=capabilities,
@@ -123,7 +123,8 @@ class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
             "manufacturer": manufacturer,
             "model": model,
             "sw_version": version_info.get("version"),
-            "identifiers": {(DOMAIN, self.api.device_id)},
+            "identifiers": {(DOMAIN, self.entry_id)},
+            "configuration_url": self.host,
         }
         try:
             return DeviceInfo(
@@ -142,10 +143,12 @@ class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
         _LOGGER.debug("Start fetching data from Clash.")
 
         try:
+            _LOGGER.debug("API Host: %s, Capabilities: %s", self.api.host, self.api.capabilities)
             response = await self.api.fetch_data(
                 streaming_detection=self.streaming_detection,
-                suppress_errors=True,
+                suppress_errors=False,
             )
+            _LOGGER.debug("Clash API Response Data: %s", response)
             if not CORE_DATA_KEYS.intersection(response):
                 raise UpdateFailed("No data returned from Clash core.")
             if not self.device:
@@ -200,6 +203,9 @@ class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
         if capabilities.get("cache_dns_flush"):
             entity_data.append(self._build_dns_flush_button())
 
+        new_data_by_unique_id = {}
+        new_data_by_name = {}
+
         for item in entity_data:
             id_source = (
                 item.unique_key
@@ -208,16 +214,18 @@ class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
                 or item.entity_type
             )
             item.unique_id = (
-                f"{self.api.device_id}"
+                f"{self.entry_id}"
                 f"_{item.entity_type}"
                 f"_{id_source.lower().replace(' ', '_')}"
             )
 
-        self._data_by_name = {}
-        for item in entity_data:
-            if item.name and item.name not in self._data_by_name:
-                self._data_by_name[item.name] = item
-        self._data_by_unique_id = {item.unique_id: item for item in entity_data}
+            new_data_by_unique_id[item.unique_id] = item
+            if item.name:
+                new_data_by_name[item.name] = item
+
+        self._data_by_unique_id = new_data_by_unique_id
+        self._data_by_name = new_data_by_name
+        
         return entity_data
 
     @staticmethod
@@ -233,7 +241,7 @@ class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
                 entity_type="traffic_sensor",
                 icon="mdi:arrow-up",
                 translation_key="up_speed",
-                unique_key="upload_speed",
+                unique_key="up_speed",
             ),
             ClashEntityData(
                 name=None,
@@ -241,7 +249,7 @@ class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
                 entity_type="traffic_sensor",
                 icon="mdi:arrow-down",
                 translation_key="down_speed",
-                unique_key="download_speed",
+                unique_key="down_speed",
             ),
         ]
 
@@ -260,7 +268,7 @@ class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
                 entity_type="total_traffic_sensor",
                 icon="mdi:tray-arrow-up",
                 translation_key="up_traffic",
-                unique_key="upload_traffic",
+                unique_key="up_traffic",
             ),
             ClashEntityData(
                 name=None,
@@ -268,7 +276,7 @@ class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
                 entity_type="total_traffic_sensor",
                 icon="mdi:tray-arrow-down",
                 translation_key="down_traffic",
-                unique_key="download_traffic",
+                unique_key="down_traffic",
             ),
             ClashEntityData(
                 name=None,
@@ -532,9 +540,9 @@ class ClashControllerCoordinator(DataUpdateCoordinator[list[ClashEntityData]]):
         return entity_data
 
     def get_data_by_name(self, name: str) -> ClashEntityData | None:
-        """Retrieve data by name."""
+        """Retrieve data by name with O(1) performance."""
         return self._data_by_name.get(name)
 
     def get_data_by_unique_id(self, unique_id: str) -> ClashEntityData | None:
-        """Retrieve data by unique ID."""
+        """Retrieve data by unique ID with O(1) performance."""
         return self._data_by_unique_id.get(unique_id)

--- a/custom_components/clash_controller/manifest.json
+++ b/custom_components/clash_controller/manifest.json
@@ -8,6 +8,6 @@
     "integration_type": "device",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/myhades/ha-clash-controller/issues",
-    "requirements": ["aiohttp>=3.8.1"],
-    "version": "0.2.1"
+    "requirements": [],
+    "version": "0.3.0"
 }

--- a/custom_components/clash_controller/select.py
+++ b/custom_components/clash_controller/select.py
@@ -72,9 +72,10 @@ class ClashSelectBase(BaseEntity, SelectEntity):
         entity_data: ClashEntityData,
         description: ClashSelectDescription
     ) -> None:
-        super().__init__(coordinator, entity_data)
         self.entity_description = description
-
+        self._attr_translation_key = description.translation_key
+        super().__init__(coordinator, entity_data)
+        
     @property
     def current_option(self) -> str | None:
         """从 entity_data 映射状态。"""
@@ -114,8 +115,6 @@ class ClashCoreModeSelect(ClashSelectBase):
 
     def __init__(self, coordinator, entity_data, description) -> None:
         super().__init__(coordinator, entity_data, description)
-
-        self._attr_name = None
 
     async def async_select_option(self, option: str) -> None:
         """执行核心模式切换（PATCH -> PUT 回退逻辑）。"""

--- a/custom_components/clash_controller/select.py
+++ b/custom_components/clash_controller/select.py
@@ -1,110 +1,138 @@
 """Select platform for Clash Controller."""
 
+from __future__ import annotations
+
 import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
 from urllib.parse import quote
 
-from homeassistant.components.select import SelectEntity
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base import BaseEntity
-from .const import DOMAIN
-from .coordinator import ClashControllerCoordinator, ClashEntityData
+
+if TYPE_CHECKING:
+    from . import ClashConfigEntry
+    from .coordinator import ClashControllerCoordinator, ClashEntityData
 
 _LOGGER = logging.getLogger(__name__)
 
+@dataclass(frozen=True, kw_only=True)
+class ClashSelectDescription(SelectEntityDescription):
+    """描述 Clash 选择器的自定义类。"""
+
+# 定义核心模式的静态描述符
+SELECT_DESCRIPTIONS: Final[dict[str, ClashSelectDescription]] = {
+    "core_mode_selector": ClashSelectDescription(
+        key="core_mode",
+        translation_key="core_mode",
+        icon="mdi:tune",
+    ),
+}
+
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    entry: ClashConfigEntry, 
     async_add_entities: AddEntitiesCallback,
-):
+) -> None:
+    """基于描述符设置选择器平台。"""
+    coordinator = entry.runtime_data.coordinator
+    entities: list[SelectEntity] = []
 
-    coordinator: ClashControllerCoordinator = hass.data[DOMAIN][config_entry.entry_id].coordinator
+    for entity_data in coordinator.data:
+        if entity_data.entity_type in ["proxy_group_selector", "core_mode_selector"]:
 
-    select_types = {
-        "proxy_group_selector": GroupSelect,
-        "core_mode_selector": CoreModeSelect,
-    }
+            description = SELECT_DESCRIPTIONS.get(entity_data.entity_type)
+            
+            if not description:
+                description = ClashSelectDescription(
+                    key=entity_data.unique_key,
+                    translation_key="proxy_group",
+                    icon="mdi:network-outline",
+                )
 
-    selects = [
-        select_types[entity_type](coordinator, entity_data)
-        for entity_data in coordinator.data
-        if (entity_type := entity_data.entity_type) in select_types
-    ]
+            if entity_data.entity_type == "core_mode_selector":
+                entities.append(ClashCoreModeSelect(coordinator, entity_data, description))
+            else:
+                entities.append(ClashGroupSelect(coordinator, entity_data, description))
 
-    async_add_entities(selects)
+    async_add_entities(entities)
 
-class SelectEntityBase(BaseEntity, SelectEntity):
-    """Base select entity class."""
+class ClashSelectBase(BaseEntity, SelectEntity):
+    """Select 平台抽象基类。"""
+    
+    entity_description: ClashSelectDescription
 
     def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
+        self, 
+        coordinator: ClashControllerCoordinator, 
+        entity_data: ClashEntityData,
+        description: ClashSelectDescription
     ) -> None:
         super().__init__(coordinator, entity_data)
-    
+        self.entity_description = description
+
     @property
     def current_option(self) -> str | None:
+        """从 entity_data 映射状态。"""
         return self.entity_data.state
 
     @property
-    def options(self) -> list[str] | None:
-        return self.entity_data.options
+    def options(self) -> list[str]:
+        """从 entity_data 映射可选列表。"""
+        return self.entity_data.options or []
 
-class GroupSelect(SelectEntityBase):
-    """Implementation of a group select."""
 
-    def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
-    ) -> None:
-        super().__init__(coordinator, entity_data)
+class ClashGroupSelect(ClashSelectBase):
+    """代理组选择器实现。"""
+
+    def __init__(self, coordinator, entity_data, description) -> None:
+        super().__init__(coordinator, entity_data, description)
+
+        self._attr_name = entity_data.name
 
     async def async_select_option(self, option: str) -> None:
-        """Change the selected option."""
+        """执行代理组切换。"""
         group = self._attr_name.strip()
-        node = option.strip()
         try:
             await self.coordinator.api.async_request(
                 "PUT",
                 f"proxies/{quote(group, safe='')}",
-                json_data={"name": node},
+                json_data={"name": option.strip()},
                 suppress_errors=False,
             )
+            self.entity_data.state = option
+            self.async_write_ha_state()
         except Exception as err:
-            raise HomeAssistantError(f"Failed to set proxy group {group} to {node}.") from err
-        self.entity_data.state = option
-        self.async_write_ha_state()
+            raise HomeAssistantError(f"设置代理组 {group} 失败: {err}") from err
 
-class CoreModeSelect(SelectEntityBase):
-    """Implementation of core mode select."""
+class ClashCoreModeSelect(ClashSelectBase):
+    """核心运行模式选择器实现。"""
 
-    def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
-    ) -> None:
-        super().__init__(coordinator, entity_data)
+    def __init__(self, coordinator, entity_data, description) -> None:
+        super().__init__(coordinator, entity_data, description)
+
+        self._attr_name = None
 
     async def async_select_option(self, option: str) -> None:
-        """Change Clash running mode."""
+        """执行核心模式切换（PATCH -> PUT 回退逻辑）。"""
         mode = option.strip()
-        if not mode:
-            raise HomeAssistantError("Mode cannot be empty.")
         try:
-            await self.coordinator.api.async_request(
-                "PATCH",
-                "configs",
-                json_data={"mode": mode},
-                suppress_errors=False,
-            )
-        except Exception:
             try:
+                # 尝试现代 PATCH 接口
                 await self.coordinator.api.async_request(
-                    "PUT",
-                    "configs",
-                    json_data={"mode": mode},
-                    suppress_errors=False,
+                    "PATCH", "configs", json_data={"mode": mode}, suppress_errors=False
                 )
-            except Exception as err:
-                raise HomeAssistantError(f"Failed to set mode to {mode}.") from err
-        self.entity_data.state = mode
-        self.async_write_ha_state()
+            except Exception:
+                # 回退到旧版 PUT 接口
+                await self.coordinator.api.async_request(
+                    "PUT", "configs", json_data={"mode": mode}, suppress_errors=False
+                )
+            
+            self.entity_data.state = mode
+            self.async_write_ha_state()
+        except Exception as err:
+            raise HomeAssistantError(f"切换核心模式至 {mode} 失败: {err}") from err

--- a/custom_components/clash_controller/sensor.py
+++ b/custom_components/clash_controller/sensor.py
@@ -1,145 +1,175 @@
 """Sensor platform for Clash Controller."""
 
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
+from dataclasses import replace
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
+    SensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfDataRate, UnitOfInformation
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .base import BaseEntity
-from .const import DOMAIN
-from .coordinator import ClashControllerCoordinator, ClashEntityData
+
+if TYPE_CHECKING:
+    from . import ClashConfigEntry
+    from .coordinator import ClashControllerCoordinator, ClashEntityData
 
 _LOGGER = logging.getLogger(__name__)
 
+SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
+    "up_speed": SensorEntityDescription(
+        key="up_speed",
+        translation_key="up_speed",
+        device_class=SensorDeviceClass.DATA_RATE,
+        native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
+        suggested_unit_of_measurement=UnitOfDataRate.MEGABYTES_PER_SECOND,
+        suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "down_speed": SensorEntityDescription(
+        key="down_speed",
+        translation_key="down_speed",
+        device_class=SensorDeviceClass.DATA_RATE,
+        native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
+        suggested_unit_of_measurement=UnitOfDataRate.MEGABYTES_PER_SECOND,
+        suggested_display_precision=2,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "up_traffic": SensorEntityDescription(
+        key="up_traffic",
+        translation_key="up_traffic",
+        device_class=SensorDeviceClass.DATA_SIZE,
+        native_unit_of_measurement=UnitOfInformation.BYTES,
+        suggested_unit_of_measurement=UnitOfInformation.MEGABYTES,
+        suggested_display_precision=2,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    "down_traffic": SensorEntityDescription(
+        key="down_traffic",
+        translation_key="down_traffic",
+        device_class=SensorDeviceClass.DATA_SIZE,
+        native_unit_of_measurement=UnitOfInformation.BYTES,
+        suggested_unit_of_measurement=UnitOfInformation.MEGABYTES,
+        suggested_display_precision=2,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    "memory_used": SensorEntityDescription(
+        key="memory_used",
+        translation_key="memory_used",
+        device_class=SensorDeviceClass.DATA_SIZE,
+        native_unit_of_measurement=UnitOfInformation.BYTES,
+        suggested_unit_of_measurement=UnitOfInformation.MEGABYTES,
+        suggested_display_precision=0,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "connection_number": SensorEntityDescription(
+        key="connection_number",
+        translation_key="connection_number",
+        icon="mdi:transit-connection",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "proxy_provider_count": SensorEntityDescription(
+        key="proxy_provider_count",
+        translation_key="proxy_provider_count",
+        icon="mdi:server-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "rule_provider_count": SensorEntityDescription(
+        key="rule_provider_count",
+        translation_key="rule_provider_count",
+        icon="mdi:file-document-outline",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+}
+
 async def async_setup_entry(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    hass: HomeAssistant, 
+    entry: ClashConfigEntry, 
+    async_add_entities: AddEntitiesCallback
 ):
+    """传感器平台。"""
+    coordinator = entry.runtime_data.coordinator
+    entities = []
 
-    coordinator: ClashControllerCoordinator = hass.data[DOMAIN][config_entry.entry_id].coordinator
+    for entity_data in coordinator.data:
 
-    sensor_types = {
-        "traffic_sensor": TrafficSensor,
-        "memory_sensor": MemorySensor,
-        "total_traffic_sensor": TotalTrafficSensor,
-        "connection_sensor": ConnectionSensor,
-        "provider_count_sensor": ProviderCountSensor,
-        "proxy_group_sensor": GroupSensor,
-        "streaming_detection": StreamingSensor,
-    }
+        if entity_data.entity_type.endswith("_sensor") or entity_data.entity_type == "streaming_detection":
+            
+            description = SENSOR_DESCRIPTIONS.get(entity_data.unique_key)
+            if not description:
 
-    sensors = [
-        sensor_types[entity_type](coordinator, entity_data)
-        for entity_data in coordinator.data
-        if (entity_type := entity_data.entity_type) in sensor_types
-    ]
+                description = SensorEntityDescription(
+                    key=entity_data.unique_key,
+                    translation_key=entity_data.translation_key,
+                    icon=entity_data.icon,
+                )
+                if entity_data.entity_type == "streaming_detection":
+                    description = replace(
+                        description,
+                        device_class=SensorDeviceClass.ENUM,
+                        options=entity_data.options
+                    )
 
-    async_add_entities(sensors)
+            entities.append(ClashSensorEntity(coordinator, entity_data, description))
 
-class SensorEntityBase(BaseEntity, SensorEntity):
-    """Base sensor entity class."""
+    async_add_entities(entities)
+
+
+class ClashSensorEntity(BaseEntity, SensorEntity):
+    """通用传感器实现。"""
+
+    entity_description: SensorEntityDescription
 
     def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
+        self, 
+        coordinator: ClashControllerCoordinator, 
+        entity_data: ClashEntityData,
+        description: SensorEntityDescription
     ) -> None:
+        """初始化传感器。"""
+
+        self.entity_description = description
+        self._attr_device_class = description.device_class
         super().__init__(coordinator, entity_data)
 
+        if entity_data.name is not None:
+            self._attr_name = entity_data.name
+        else:
+            if hasattr(self, "_attr_name"):
+                delattr(self, "_attr_name")
+
     @property
-    def native_value(self) -> int | None:
-        """Default state of the base sensor."""
+    def native_value(self) -> float | int | str | None:
+        """数值处理逻辑。"""
         value = self.entity_data.state
-        return int(value) if value is not None else None
+        if value is None:
+            return None
 
-class TrafficSensor(SensorEntityBase):
-    """Implementation of a traffic sensor."""
+        if self.entity_data.entity_type in ["proxy_group_sensor", "streaming_detection"]:
+            return value
 
-    def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
-    ) -> None:
-        super().__init__(coordinator, entity_data)
-        self._attr_device_class = SensorDeviceClass.DATA_RATE
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_native_unit_of_measurement = UnitOfDataRate.BYTES_PER_SECOND
-        self._attr_suggested_unit_of_measurement = "MB/s"
-        self._attr_suggested_display_precision = 2
+        try:
 
-class TotalTrafficSensor(SensorEntityBase):
-    """Implementation of a traffic sensor."""
+            if self.entity_description.suggested_display_precision and self.entity_description.suggested_display_precision > 0:
+                return float(value)
 
-    def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
-    ) -> None:
-        super().__init__(coordinator, entity_data)
-        self._attr_device_class = SensorDeviceClass.DATA_SIZE
-        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        self._attr_native_unit_of_measurement = UnitOfInformation.BYTES
-        self._attr_suggested_unit_of_measurement = "GB"
-        self._attr_suggested_display_precision = 2
+            return int(float(value))
+            
+        except (ValueError, TypeError):
 
-class ConnectionSensor(SensorEntityBase):
-    """Implementation of a traffic sensor."""
-
-    def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
-    ) -> None:
-        super().__init__(coordinator, entity_data)
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-
-class ProviderCountSensor(SensorEntityBase):
-    """Implementation of provider count sensor."""
-
-    def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
-    ) -> None:
-        super().__init__(coordinator, entity_data)
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-
-class MemorySensor(SensorEntityBase):
-    """Implementation of a memory sensor."""
-
-    def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
-    ) -> None:
-        super().__init__(coordinator, entity_data)
-        self._attr_device_class = SensorDeviceClass.DATA_SIZE
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_native_unit_of_measurement = UnitOfInformation.BYTES
-        self._attr_suggested_unit_of_measurement = "MB"
-        self._attr_suggested_display_precision = 0
-
-class GroupSensor(SensorEntityBase):
-    """Implementation of a memory sensor."""
-
-    def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
-    ) -> None:
-        super().__init__(coordinator, entity_data)
-    
-    @property
-    def native_value(self) -> str | None:
-        return self.entity_data.state
-
-class StreamingSensor(SensorEntityBase):
-    """Implementation of a streaming service detection sensor."""
-
-    def __init__(
-        self, coordinator: ClashControllerCoordinator, entity_data: ClashEntityData
-    ) -> None:
-        super().__init__(coordinator, entity_data)
-        self._attr_device_class = SensorDeviceClass.ENUM
-
-    @property
-    def options(self) -> list[str] | None:
-        return self.entity_data.options
-    
-    @property
-    def native_value(self) -> str | None:
-        return self.entity_data.state
+            if self.entity_description.state_class or self.entity_description.device_class:
+                _LOGGER.debug(
+                    " entity %s 的 API 值 '%s' 无法解析为数字，已安全置为 None", 
+                    self.entity_id, value
+                )
+                return None
+                
+            return value

--- a/custom_components/clash_controller/services.py
+++ b/custom_components/clash_controller/services.py
@@ -1,15 +1,18 @@
-"""Services for the Clash Controller."""
+"""Services for the Clash Controller integration."""
+
+from __future__ import annotations
 
 import asyncio
 import json
+from typing import Any, Final
 from urllib.parse import quote
+
 import voluptuous as vol
 
 from homeassistant.const import CONF_DEVICE_ID
-from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
+from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 
 from .const import (
     DOMAIN,
@@ -20,379 +23,223 @@ from .const import (
     GET_RULE_SERVICE_NAME,
     API_CALL_SERVICE_NAME,
 )
-from .coordinator import ClashControllerCoordinator
 
-HOST_KEYWORD = "host"
-SRC_HOSTNAME_KEYWORD = "src_hostname"
-DES_HOSTNAME_KEYWORD = "des_hostname"
-CLOSE_CONNECTION = "close_connection"
+# --- 参数常量定义  ---
+ATTR_HOST: Final = "host"
+ATTR_SRC_HOSTNAME: Final = "src_hostname"
+ATTR_DES_HOSTNAME: Final = "des_hostname"
+ATTR_CLOSE_CONNECTION: Final = "close_connection"
+ATTR_GROUP: Final = "group"
+ATTR_NODE: Final = "node"
+ATTR_URL: Final = "url"
+ATTR_TIMEOUT: Final = "timeout"
+ATTR_DOMAIN_NAME: Final = "domain_name"
+ATTR_RECORD_TYPE: Final = "record_type"
+ATTR_RULE_TYPE: Final = "rule_type"
+ATTR_RULE_PAYLOAD: Final = "rule_payload"
+ATTR_RULE_PROXY: Final = "rule_proxy"
+ATTR_API_ENDPOINT: Final = "api_endpoint"
+ATTR_API_METHOD: Final = "api_method"
+ATTR_API_PARAMS: Final = "api_params"
+ATTR_API_DATA: Final = "api_data"
+ATTR_READ_LINE: Final = "read_line"
 
-GROUP_NAME = "group"
-NODE_NAME = "node"
-TEST_URL = "url"
-TEST_TIMEOUT = "timeout"
+# --- 校验架构 (Schemas) ---
+REBOOT_CORE_SERVICE_SCHEMA = vol.Schema({
+    vol.Required(CONF_DEVICE_ID): cv.string,
+})
 
-DOMAIN_NAME = "domain_name"
-RECORD_TYPE = "record_type"
+FILTER_CONNECTION_SCHEMA = vol.Schema({
+    vol.Required(CONF_DEVICE_ID): cv.string,
+    vol.Optional(ATTR_CLOSE_CONNECTION, default=False): cv.boolean,
+    vol.Optional(ATTR_HOST): cv.string,
+    vol.Optional(ATTR_SRC_HOSTNAME): cv.string,
+    vol.Optional(ATTR_DES_HOSTNAME): cv.string,
+})
 
-RULE_TYPE = "rule_type"
-RULE_PAYLOAD = "rule_payload"
-RULE_PROXY = "rule_proxy"
+GET_LATENCY_SCHEMA = vol.Schema({
+    vol.Required(CONF_DEVICE_ID): cv.string,
+    vol.Optional(ATTR_GROUP): cv.string,
+    vol.Optional(ATTR_NODE): cv.string,
+    vol.Optional(ATTR_URL, default="http://www.gstatic.com/generate_204"): cv.string,
+    vol.Optional(ATTR_TIMEOUT, default=5000): cv.positive_int,
+})
 
-API_ENDPOINT = "api_endpoint"
-API_METHOD = "api_method"
-API_PARAMS = "api_params"
-API_DATA = "api_data"
-API_READ_LINE = "read_line"
+DNS_QUERY_SCHEMA = vol.Schema({
+    vol.Required(CONF_DEVICE_ID): cv.string,
+    vol.Required(ATTR_DOMAIN_NAME): cv.string,
+    vol.Optional(ATTR_RECORD_TYPE, default="A"): cv.string,
+})
 
-REBOOT_CORE_SERVICE_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_DEVICE_ID): cv.string,
-    }
-)
+GET_RULE_SCHEMA = vol.Schema({
+    vol.Required(CONF_DEVICE_ID): cv.string,
+    vol.Optional(ATTR_RULE_TYPE): cv.string,
+    vol.Optional(ATTR_RULE_PAYLOAD): cv.string,
+    vol.Optional(ATTR_RULE_PROXY): cv.string,
+})
 
-FILTER_CONNECTION_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_DEVICE_ID): cv.string,
-        vol.Optional(CLOSE_CONNECTION): cv.boolean,
-        vol.Optional(HOST_KEYWORD): cv.string,
-        vol.Optional(SRC_HOSTNAME_KEYWORD): cv.string,
-        vol.Optional(DES_HOSTNAME_KEYWORD): cv.string,
-    }
-)
+API_CALL_SCHEMA = vol.Schema({
+    vol.Required(CONF_DEVICE_ID): cv.string,
+    vol.Required(ATTR_API_ENDPOINT): cv.string,
+    vol.Required(ATTR_API_METHOD): cv.string,
+    vol.Optional(ATTR_API_PARAMS): cv.string,
+    vol.Optional(ATTR_API_DATA): cv.string,
+    vol.Optional(ATTR_READ_LINE): cv.positive_int,
+})
 
-GET_LATENCY_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_DEVICE_ID): cv.string,
-        vol.Optional(GROUP_NAME): cv.string,
-        vol.Optional(NODE_NAME): cv.string,
-        vol.Optional(TEST_URL): cv.string,
-        vol.Optional(TEST_TIMEOUT): cv.positive_int,
-    }
-)
+async def async_setup_services(hass: HomeAssistant) -> None:
+    """注册集成服务。此函数在 __init__.py 中被调用。"""
 
-DNS_QUERY_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_DEVICE_ID): cv.string,
-        vol.Required(DOMAIN_NAME): cv.string,
-        vol.Optional(RECORD_TYPE): cv.string,
-    }
-)
-
-GET_RULE_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_DEVICE_ID): cv.string,
-        vol.Optional(RULE_TYPE): cv.string,
-        vol.Optional(RULE_PAYLOAD): cv.string,
-        vol.Optional(RULE_PROXY): cv.string,
-    }
-)
-
-API_CALL_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_DEVICE_ID): cv.string,
-        vol.Required(API_ENDPOINT): cv.string,
-        vol.Required(API_METHOD): cv.string,
-        vol.Optional(API_PARAMS): cv.string,
-        vol.Optional(API_DATA): cv.string,
-        vol.Optional(API_READ_LINE): cv.positive_int,
-    }
-)
-
-class ClashServicesSetup:
-    """Class to handle Integration Services."""
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        self.hass = hass
-        self.setup_services()
-
-    def setup_services(self):
-        """Initialise the services."""
-
-        def _register(
-            service_name: str,
-            handler,
-            schema: vol.Schema,
-            supports_response: SupportsResponse | None = None,
-        ) -> None:
-            if self.hass.services.has_service(DOMAIN, service_name):
-                return
-            kwargs = {"schema": schema}
-            if supports_response is not None:
-                kwargs["supports_response"] = supports_response
-            self.hass.services.async_register(
-                DOMAIN,
-                service_name,
-                handler,
-                **kwargs,
-            )
-
-        _register(
-            REBOOT_CORE_SERVICE_NAME,
-            self.async_reboot_core_service,
-            REBOOT_CORE_SERVICE_SCHEMA,
-        )
-        _register(
-            FILTER_CONNECTION_SERVICE_NAME,
-            self.async_filter_connection_service,
-            FILTER_CONNECTION_SCHEMA,
-            supports_response=SupportsResponse.OPTIONAL,
-        )
-        _register(
-            GET_LATENCY_SERVICE_NAME,
-            self.async_get_latency_service,
-            GET_LATENCY_SCHEMA,
-            supports_response=SupportsResponse.ONLY,
-        )
-        _register(
-            DNS_QUERY_SERVICE_NAME,
-            self.async_dns_query_service,
-            DNS_QUERY_SCHEMA,
-            supports_response=SupportsResponse.ONLY,
-        )
-        _register(
-            GET_RULE_SERVICE_NAME,
-            self.async_get_rule_service,
-            GET_RULE_SCHEMA,
-            supports_response=SupportsResponse.ONLY,
-        )
-        _register(
-            API_CALL_SERVICE_NAME,
-            self.async_api_call_service,
-            API_CALL_SCHEMA,
-            supports_response=SupportsResponse.OPTIONAL,
-        )
-
-    def _get_coordinator(self, device_id: str) -> ClashControllerCoordinator:
-        """Get the corresponding coordinator with given device_id."""
-
-        dev_reg = dr.async_get(self.hass)
+    def _get_coordinator(device_id: str) -> Any:
+        dev_reg = dr.async_get(hass)
         device = dev_reg.async_get(device_id)
         if not device:
-            raise HomeAssistantError("Invalid device id.")
-        config_entry_id = next(iter(device.config_entries), None)
-        if not config_entry_id:
-            raise HomeAssistantError("Invalid device id.")
-        runtime_data = self.hass.data.get(DOMAIN, {}).get(config_entry_id)
-        if not runtime_data:
-            raise HomeAssistantError("Invalid device id.")
-        return runtime_data.coordinator
-
-    async def async_reboot_core_service(self, service_call: ServiceCall) -> None:
-        """Execute service call for rebooting core."""
-
-        coordinator = self._get_coordinator(service_call.data[CONF_DEVICE_ID])
+            raise HomeAssistantError(f"未找到 ID 为 {device_id} 的设备")
         
+        entry_id = next(iter(device.config_entries), None)
+        if not entry_id:
+            raise HomeAssistantError(f"设备 {device_id} 没有关联的配置条目")
+            
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if not entry or not hasattr(entry, "runtime_data"):
+            raise HomeAssistantError(f"配置条目 {entry_id} 尚未就绪")
+            
+        return entry.runtime_data.coordinator
+
+    def parse_filter_list(value: str | None) -> set[str] | None:
+        if not value:
+            return None
+        return {item.strip().lower() for item in value.split(",") if item.strip()}
+
+    def to_dict(input_val: Any) -> dict:
+        if isinstance(input_val, dict):
+            return input_val
+        if not input_val or not isinstance(input_val, str):
+            return {}
         try:
-            await coordinator.api.async_request("POST", "restart", suppress_errors=False)
-        except Exception as err:
-            raise HomeAssistantError(f"Error rebooting core: {err}") from err
+            data = json.loads(input_val)
+            return data if isinstance(data, dict) else {}
+        except json.JSONDecodeError:
+            return {}
 
-    async def async_filter_connection_service(self, service_call: ServiceCall) -> dict:
-        """Execute service call for filtering connection."""
+    # --- 处理器定义 ---
 
-        coordinator = self._get_coordinator(service_call.data[CONF_DEVICE_ID])
+    async def handle_reboot_core(call: ServiceCall) -> None:
+        coordinator = _get_coordinator(call.data[CONF_DEVICE_ID])
+        await coordinator.api.async_request("POST", "restart", suppress_errors=False)
 
-        def parse_filter(key):
-            value_str = service_call.data.get(key)
-            return (
-                {item.strip().lower() for item in value_str.split(",") if item.strip()}
-                if value_str
-                else None
-            )
+    async def handle_filter_connection(call: ServiceCall) -> ServiceResponse:
+        coordinator = _get_coordinator(call.data[CONF_DEVICE_ID])
+        hosts = parse_filter_list(call.data.get(ATTR_HOST))
+        src_hosts = parse_filter_list(call.data.get(ATTR_SRC_HOSTNAME))
+        des_hosts = parse_filter_list(call.data.get(ATTR_DES_HOSTNAME))
+        close_connection = call.data[ATTR_CLOSE_CONNECTION]
 
-        def filter_connection(conn):
-            meta = conn.get("metadata", {})
-            host = meta.get("host", "").lower()
-            src_ip = meta.get("sourceIP", "").lower()
-            des_ip = meta.get("destinationIP", "").lower()
-            if hosts and not any(h in host for h in hosts):
-                return False
-            if src_hosts and not any(h in src_ip for h in src_hosts):
-                return False
-            if des_hosts and not any(h in des_ip for h in des_hosts):
-                return False
-            return True
-
-        async def delete_connection(conn_id):
-            async with semaphore:
-                await coordinator.api.async_request(
-                    "DELETE",
-                    f"connections/{conn_id}",
-                    suppress_errors=False,
-                )
-
-        hosts = parse_filter(HOST_KEYWORD)
-        src_hosts = parse_filter(SRC_HOSTNAME_KEYWORD)
-        des_hosts = parse_filter(DES_HOSTNAME_KEYWORD)
-        close_connection = service_call.data.get(CLOSE_CONNECTION, False)
-
-        try:
-            response = await coordinator.api.async_request("GET", "connections", suppress_errors=False)
-        except Exception as err:
-            raise HomeAssistantError(f"Error getting connections: {err}") from err
-
+        response = await coordinator.api.async_request("GET", "connections", suppress_errors=False)
         connections = response.get("connections", []) or []
-        filtered_connections = [conn for conn in connections if filter_connection(conn)]
+        
+        filtered = [
+            c for c in connections if 
+            (not hosts or any(h in c.get("metadata", {}).get("host", "").lower() for h in hosts)) and
+            (not src_hosts or any(sh in c.get("metadata", {}).get("sourceIP", "").lower() for sh in src_hosts)) and
+            (not des_hosts or any(dh in c.get("metadata", {}).get("destinationIP", "").lower() for dh in des_hosts))
+        ]
 
-        service_response = {
-            "connection_number": len(filtered_connections),
+        if close_connection and filtered:
+            if hosts or src_hosts or des_hosts:
+                semaphore = asyncio.Semaphore(5)
+                async def delete_conn(cid):
+                    async with semaphore:
+                        await coordinator.api.async_request("DELETE", f"connections/{cid}")
+                await asyncio.gather(*[delete_conn(c["id"]) for c in filtered], return_exceptions=True)
+            else:
+                await coordinator.api.async_request("DELETE", "connections", suppress_errors=False)
+
+        return {
+            "connection_number": len(filtered),
             "connection_closed": close_connection,
-            "connections": filtered_connections,
+            "connections": filtered[:100],
         }
 
-        if not close_connection:
-            return service_response
-
-        try:
-            if hosts or src_hosts or des_hosts:
-                semaphore = asyncio.Semaphore(coordinator.concurrent_connections)
-                await asyncio.gather(*[
-                    delete_connection(conn["id"]) for conn in filtered_connections
-                ])
-            else:
-                await coordinator.api.async_request(
-                    "DELETE",
-                    "connections",
-                    suppress_errors=False,
-                )
-        except Exception as err:
-            raise HomeAssistantError(f"Error closing connection: {err}") from err
-
-        return service_response
-
-    async def async_get_latency_service(self, service_call: ServiceCall) -> dict:
-        """Execute service call for getting latency."""
-
-        coordinator = self._get_coordinator(service_call.data[CONF_DEVICE_ID])
-
-        def sort_group(data: dict) -> dict:
-            if not data:
-                return {"fastest_node": None,"latency": []}
-            sorted_items = sorted(data.items(), key=lambda x: x[1])
-            return {
-                "fastest_node": sorted_items[0][0],
-                "latency": sorted_items
-            }
+    async def handle_get_latency(call: ServiceCall) -> ServiceResponse:
+        coordinator = _get_coordinator(call.data[CONF_DEVICE_ID])
+        group = call.data.get(ATTR_GROUP, "").strip()
+        node = call.data.get(ATTR_NODE, "").strip()
+        endpoint = f"group/{quote(group)}/delay" if group else f"proxies/{quote(node)}/delay"
         
-        group = service_call.data.get(GROUP_NAME, "").strip()
-        node = service_call.data.get(NODE_NAME, "").strip()
-        url = service_call.data.get(TEST_URL, "http://www.gstatic.com/generate_204")
-        timeout = service_call.data.get(TEST_TIMEOUT, 5000)
-        
-        if bool(group) ^ bool(node) is False:
-            raise HomeAssistantError("Exactly one of the group or node should be provided.")
-
-        try:
-            response = await coordinator.api.async_request(
-                method="GET",
-                endpoint=(
-                    f"group/{quote(group, safe='')}/delay"
-                    if group
-                    else f"proxies/{quote(node, safe='')}/delay"
-                ),
-                params={"url": url,"timeout": timeout},
-                suppress_errors=False
-            )
-        except Exception as err:
-            raise HomeAssistantError(f"Error getting latency: {err}") from err
-        
+        response = await coordinator.api.async_request(
+            "GET", endpoint, 
+            params={"url": call.data[ATTR_URL], "timeout": call.data[ATTR_TIMEOUT]},
+            suppress_errors=False
+        )
         if group:
-            return sort_group(response)
-        else:
-            return {"latency": {node: response.get("delay", [])}}
+            sorted_items = sorted(response.items(), key=lambda x: x[1])
+            return {"fastest_node": sorted_items[0][0] if sorted_items else None, "latency": sorted_items}
+        return {"latency": {node: response.get("delay", [])}}
 
-    async def async_dns_query_service(self, service_call: ServiceCall) -> dict:
-        """Execute service call for performing a DNS query."""
+    async def handle_dns_query(call: ServiceCall) -> ServiceResponse:
+        coordinator = _get_coordinator(call.data[CONF_DEVICE_ID])
+        return await coordinator.api.async_request(
+            "GET", "dns/query", 
+            params={"name": call.data[ATTR_DOMAIN_NAME], "type": call.data[ATTR_RECORD_TYPE]},
+            suppress_errors=False
+        )
 
-        coordinator = self._get_coordinator(service_call.data[CONF_DEVICE_ID])
-
-        domain_name = service_call.data.get(DOMAIN_NAME, "")
-        record_type = service_call.data.get(RECORD_TYPE, "A")
-
-        try:
-            return await coordinator.api.async_request(
-                method="GET",
-                endpoint="dns/query",
-                params={"name": domain_name,"type": record_type},
-                suppress_errors=False
-            )
-        except Exception as err:
-            raise HomeAssistantError(f"Error performing DNS query: {err}") from err
-
-    async def async_get_rule_service(self, service_call: ServiceCall) -> dict:
-        """Execute service call for performing a DNS query."""
-
-        coordinator = self._get_coordinator(service_call.data[CONF_DEVICE_ID])
-
-        def parse_filter(key):
-            value_str = service_call.data.get(key)
-            return (
-                {item.strip().lower() for item in value_str.split(",") if item.strip()}
-                if value_str
-                else None
-            )
-
-        def filter_rule(rule):
-            rule_type = rule.get("type", "").lower()
-            rule_payload = rule.get("payload", "").lower()
-            rule_proxy = rule.get("proxy", "").lower()
-            if rule_types and not any(h in rule_type for h in rule_types):
-                return False
-            if rule_payloads and not any(h in rule_payload for h in rule_payloads):
-                return False
-            if rule_proxys and not any(h in rule_proxy for h in rule_proxys):
-                return False
-            return True
-
-        rule_types = parse_filter(RULE_TYPE)
-        rule_payloads = parse_filter(RULE_PAYLOAD)
-        rule_proxys = parse_filter(RULE_PROXY)
-
-        try:
-            response = await coordinator.api.async_request(method="GET",endpoint="rules",suppress_errors=False)
-        except Exception as err:
-            raise HomeAssistantError(f"Error getting rules: {err}") from err
-
-        rules = response.get("rules", [])
-        filtered_rules = [rule for rule in rules if filter_rule(rule)]
-        service_response = {"rules": filtered_rules}
-
-        return service_response
-
-    async def async_api_call_service(self, service_call: ServiceCall) -> None:
-        """Execute service call for calling API."""
-
-        coordinator = self._get_coordinator(service_call.data[CONF_DEVICE_ID])
-
-        def to_dict(input_str: str):
-            try:
-                data = json.loads(input_str)
-                if isinstance(data, dict):
-                    return data
-                else:
-                    return {}
-            except json.JSONDecodeError:
-                return {}
-
-        method = service_call.data.get(API_METHOD, "GET")
-        endpoint = service_call.data.get(API_ENDPOINT, "")
-        read_line = service_call.data.get(API_READ_LINE, 0)
-        params = to_dict(service_call.data.get(API_PARAMS, "") or "")
-        data = to_dict(service_call.data.get(API_DATA, "") or "")
+    async def handle_get_rule(call: ServiceCall) -> ServiceResponse:
+        coordinator = _get_coordinator(call.data[CONF_DEVICE_ID])
+        response = await coordinator.api.async_request("GET", "rules", suppress_errors=False)
+        r_type = call.data.get(ATTR_RULE_TYPE, "").lower()
+        r_payload = call.data.get(ATTR_RULE_PAYLOAD, "").lower()
+        r_proxy = call.data.get(ATTR_RULE_PROXY, "").lower()
         
-        try:
-            response = await coordinator.api.async_request(
-                method=method,
-                endpoint=endpoint,
-                params=params,
-                json_data=data,
-                read_line=read_line,
-                suppress_errors=False
-            )
-        except Exception as err:
-            raise HomeAssistantError(f"Error performing API call: {err}") from err
-        
-        return {"response": response}
+        filtered = [
+            r for r in response.get("rules", [])
+            if (not r_type or r_type in r.get("type", "").lower()) and
+               (not r_payload or r_payload in r.get("payload", "").lower()) and
+               (not r_proxy or r_proxy in r.get("proxy", "").lower())
+        ]
+        return {"rules": filtered}
 
+    async def handle_api_call(call: ServiceCall) -> ServiceResponse:
+        coordinator = _get_coordinator(call.data[CONF_DEVICE_ID])
+        res = await coordinator.api.async_request(
+            method=call.data[ATTR_API_METHOD],
+            endpoint=call.data[ATTR_API_ENDPOINT],
+            params=to_dict(call.data.get(ATTR_API_PARAMS)),
+            json_data=to_dict(call.data.get(ATTR_API_DATA)),
+            read_line=call.data.get(ATTR_READ_LINE, 0),
+            suppress_errors=False
+        )
+        return {"response": res}
 
+    # --- 注册服务 ---
+    
+    hass.services.async_register(
+        DOMAIN, REBOOT_CORE_SERVICE_NAME, handle_reboot_core, 
+        schema=REBOOT_CORE_SERVICE_SCHEMA
+    )
+    
+    hass.services.async_register(
+        DOMAIN, FILTER_CONNECTION_SERVICE_NAME, handle_filter_connection, 
+        schema=FILTER_CONNECTION_SCHEMA, supports_response=SupportsResponse.OPTIONAL
+    )
+    
+    hass.services.async_register(
+        DOMAIN, GET_LATENCY_SERVICE_NAME, handle_get_latency, 
+        schema=GET_LATENCY_SCHEMA, supports_response=SupportsResponse.ONLY
+    )
+    
+    hass.services.async_register(
+        DOMAIN, DNS_QUERY_SERVICE_NAME, handle_dns_query, 
+        schema=DNS_QUERY_SCHEMA, supports_response=SupportsResponse.ONLY
+    )
+    
+    hass.services.async_register(
+        DOMAIN, GET_RULE_SERVICE_NAME, handle_get_rule, 
+        schema=GET_RULE_SCHEMA, supports_response=SupportsResponse.ONLY
+    )
+    
+    hass.services.async_register(
+        DOMAIN, API_CALL_SERVICE_NAME, handle_api_call, 
+        schema=API_CALL_SCHEMA, supports_response=SupportsResponse.OPTIONAL
+    )

--- a/custom_components/clash_controller/translations/en.json
+++ b/custom_components/clash_controller/translations/en.json
@@ -1,251 +1,262 @@
 {
-    "title": "Clash Controller",
-    "config": {
-        "step": {
-            "user": {
-                "title": "Clash Controller Setup",
-                "data": {
-                    "api_url": "API",
-                    "bearer_token": "Token",
-                    "use_ssl": "Use HTTPS",
-                    "allow_unsafe": "Allow Unsafe SSL Certificates"
-                },
-                "description": "Enter the API address and token for your Clash instance. Examples: 192.168.1.1:9090, clash.mydomain.com. If the location is an IP address, make sure it's static."
-            }
-        },        
-        "error": {
-            "cannot_connect": "Failed to connect to the API. Verify the address and try again.",
-            "invalid_token": "The provided API token is invalid. Please check and try again.",
-            "unknown": "An unexpected error occurred. Please try again later.",
-            "timed_out": "API connection timed out. Is Clash running?"
-        },
-        "abort": {
-            "already_configured": "The instance at this location is already added. Use configure button to update token and modify settings."
-          }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "description": "Modify options of this entry. To detect streaming service availability, Home Assistant must connect through the same proxy being tested.",
-                "title": "Clash Controller Options",
-                "data": {
-                    "scan_interval": "Scan Interval (seconds)",
-                    "concurrent_connections": "Concurrent Connections",
-                    "bearer_token": "Update Bearer Token (Leave empty to skip)",
-                    "streaming_detection": "Enable Streaming Service Availability Detection"
-                }
-            }
-        },        
-        "error": {
-            "invalid_token": "The provided API token is invalid. Please check and try again."
+  "title": "Clash Controller",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Clash Controller Setup",
+        "description": "Enter the API address and token for your Clash instance. Examples: 192.168.1.1:9090, clash.mydomain.com. If the location is an IP address, make sure it's static.",
+        "data": {
+          "api_url": "API",
+          "bearer_token": "Token",
+          "use_ssl": "Use HTTPS",
+          "allow_unsafe": "Allow Unsafe SSL Certificates"
         }
-    },
-    "device": {
-        "clash_instance": {
-            "name": "Clash Instance"
+      },
+      "reconfigure": {
+        "title": "Reconfigure Clash Connection",
+        "description": "Please update the connection settings or credentials for this Clash instance.",
+        "data": {
+          "api_url": "API URL",
+          "bearer_token": "Secret Token (Secret)",
+          "use_ssl": "Use SSL",
+          "allow_unsafe": "Allow Unsafe Certificates"
         }
+      }
     },
-    "entity": {
-        "button":{
-          "flush_cache": {
-            "name": "Flush FakeIP Cache"
-          },
-          "flush_dns_cache": {
-            "name": "Flush DNS Cache"
-          },
-          "provider_healthcheck": {
-            "name": "{provider_name} Healthcheck"
-          },
-          "default_proxy_group_healthcheck": {
-            "name": "Default Proxy Group Healthcheck"
-          }
+    "error": {
+      "cannot_connect": "Failed to connect to the API. Verify the address and try again.",
+      "invalid_token": "The provided API token is invalid. Please check and try again.",
+      "unknown": "An unexpected error occurred. Please try again later.",
+      "timed_out": "API connection timed out. Is Clash running?"
+    },
+    "abort": {
+      "already_configured": "The instance at this location is already added. Use configure button to update token and modify settings.",
+      "reconfigure_successful": "Reconfiguration successful."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Clash Controller Options",
+        "description": "Modify options of this entry. To detect streaming service availability, Home Assistant must connect through the same proxy being tested.",
+        "data": {
+          "scan_interval": "Scan Interval (seconds)",
+          "concurrent_connections": "Concurrent Connections",
+          "bearer_token": "Update Bearer Token (Leave empty to skip)",
+          "streaming_detection": "Enable Streaming Service Availability Detection"
+        }
+      }
+    },
+    "error": {
+      "invalid_token": "The provided API token is invalid. Please check and try again."
+    }
+  },
+  "device": {
+    "clash_instance": {
+      "name": "Clash Instance"
+    }
+  },
+  "entity": {
+    "button": {
+      "default_proxy_group_healthcheck": {
+        "name": "Default Proxy Group Healthcheck"
+      },
+      "flush_cache": {
+        "name": "Flush FakeIP Cache"
+      },
+      "flush_dns_cache": {
+        "name": "Flush DNS Cache"
+      },
+      "provider_healthcheck": {
+        "name": "{provider_name} Healthcheck"
+      }
+    },
+    "select": {
+      "core_mode": {
+        "name": "Proxy Mode",
+        "state": {
+          "rule": "Rule",
+          "global": "Global",
+          "direct": "Direct",
+          "script": "Script"
+        }
+      }
+    },
+    "sensor": {
+      "up_speed": {
+        "name": "Upload Speed"
+      },
+      "down_speed": {
+        "name": "Download Speed"
+      },
+      "up_traffic": {
+        "name": "Upload Traffic"
+      },
+      "down_traffic": {
+        "name": "Download Traffic"
+      },
+      "memory_used": {
+        "name": "Memory Used"
+      },
+      "connection_number": {
+        "name": "Connection Number"
+      },
+      "proxy_provider_count": {
+        "name": "Proxy Provider Count"
+      },
+      "rule_provider_count": {
+        "name": "Rule Provider Count"
+      },
+      "netflix_service": {
+        "name": "Netflix",
+        "state": {
+          "unlocked": "Unlocked",
+          "blocked": "Blocked",
+          "original_only": "Original Only"
         },
-        "select": {
-          "core_mode": {
-            "name": "Proxy Mode",
-            "state": {
-                "rule": "Rule",
-                "global": "Global",
-                "direct": "Direct",
-                "script": "Script"
-            }
-          }
-        },
-        "sensor": {
-          "up_speed": {
-            "name": "Upload Speed"
+        "state_attributes": {
+          "latency": {
+            "name": "Latency"
           },
-          "down_speed": {
-            "name": "Download Speed"
-          },
-          "up_traffic": {
-            "name": "Upload Traffic"
-          },
-          "down_traffic": {
-            "name": "Download Traffic"
-          },
-          "memory_used": {
-            "name": "Memory Used"
-          },
-          "connection_number": {
-            "name": "Connection Number"
-          },
-          "proxy_provider_count": {
-            "name": "Proxy Provider Count"
-          },
-          "rule_provider_count": {
-            "name": "Rule Provider Count"
-          },
-          "netflix_service": {
-            "name": "Netflix",
-            "state":{
-                "unlocked": "Unlocked",
-                "blocked": "Blocked",
-                "original_only": "Original Only"
-            },
-            "state_attributes":{
-                "latency": {
-                    "name": "Latency"
-                },
-                "status_code": {
-                    "name": "Status Code"
-                }
-            }
+          "status_code": {
+            "name": "Status Code"
           }
         }
+      }
+    }
+  },
+  "services": {
+    "reboot_core_service": {
+      "name": "Reboot Clash Core",
+      "description": "Reboot the core of the remote Clash instance.",
+      "fields": {
+        "device_id": {
+          "name": "Instance",
+          "description": "Select the target instance"
+        }
+      }
     },
-    "services": {
-        "reboot_core_service": {
-          "name": "Reboot Clash Core",
-          "description": "Reboot the core of the remote Clash instance.",
-          "fields": {
-            "device_id": {
-              "name": "Instance",
-              "description": "Select the target instance"
-            }
-          }
+    "filter_connection_service": {
+      "name": "Filter Connection",
+      "description": "Retrieve and optionally close active connections using keyword filters. Separate multiple keywords with comma \",\". Keywords are case-insensitive.",
+      "fields": {
+        "device_id": {
+          "name": "Instance",
+          "description": "Select the target instance"
         },
-        "filter_connection_service": {
-            "name": "Filter Connection",
-            "description": "Retrieve and optionally close active connections using keyword filters. Separate multiple keywords with comma \",\". Keywords are case-insensitive.",
-            "fields": {
-                "device_id": {
-                    "name": "Instance",
-                    "description": "Select the target instance"
-                },
-                "close_connection": {
-                    "name": "Close Connection",
-                    "description": "If enabled, retrieved connections will also be closed"
-                },
-                "host": {
-                    "name": "Host",
-                    "description": "Filter by host"
-                },
-                "src_hostname": {
-                    "name": "Source IP",
-                    "description": "Filter by source IP"
-                },
-                "des_hostname": {
-                    "name": "Destination IP",
-                    "description": "Filter by destination IP"
-                }
-            }
+        "close_connection": {
+          "name": "Close Connection",
+          "description": "If enabled, retrieved connections will also be closed"
         },
-        "get_latency_service": {
-            "name": "Get Latency",
-            "description": "Get the latency of a specified node or group. Only one field should be provided at a time. A 504 error may occur if the URL is misconfigured or the request times out.",
-            "fields": {
-                "device_id": {
-                    "name": "Instance",
-                    "description": "Select the target instance"
-                },
-                "group": {
-                    "name": "Group Name",
-                    "description": "The proxy group name. Testing a group will also clear its fixed option if set"
-                },
-                "node": {
-                    "name": "Node Name",
-                    "description": "The proxy node name"
-                },
-                "url": {
-                    "name": "URL",
-                    "description": "The URL used to test the latency"
-                },
-                "timeout": {
-                    "name": "Timeout",
-                    "description": "Connection timeout in milliseconds"
-                }
-            }
+        "host": {
+          "name": "Host",
+          "description": "Filter by host"
         },
-        "dns_query_service": {
-            "name": "DNS Query",
-            "description": "Perform a DNS query with Clash.",
-            "fields": {
-                "device_id": {
-                    "name": "Instance",
-                    "description": "Select the target instance"
-                },
-                "domain_name": {
-                    "name": "Domain Name",
-                    "description": "The domain name to query"
-                },
-                "record_type": {
-                    "name": "Record Type",
-                    "description": "The record type to query. Leave empty to get IPv4 (A) record"
-                }
-            }
+        "src_hostname": {
+          "name": "Source IP",
+          "description": "Filter by source IP"
         },
-        "get_rule_service": {
-            "name": "Get Rule",
-            "description": "Get rules using keyword filters.",
-            "fields": {
-                "device_id": {
-                    "name": "Instance",
-                    "description": "Select the target instance"
-                },
-                "rule_type": {
-                    "name": "Type",
-                    "description": "The type of the rule"
-                },
-                "rule_payload": {
-                    "name": "Payload",
-                    "description": "The payload to match"
-                },
-                "rule_proxy": {
-                    "name": "Proxy",
-                    "description": "The proxy method used"
-                }
-            }
+        "des_hostname": {
+          "name": "Destination IP",
+          "description": "Filter by destination IP"
+        }
+      }
+    },
+    "get_latency_service": {
+      "name": "Get Latency",
+      "description": "Get the latency of a specified node or group. Only one field should be provided at a time. A 504 error may occur if the URL is misconfigured or the request times out.",
+      "fields": {
+        "device_id": {
+          "name": "Instance",
+          "description": "Select the target instance"
         },
-        "api_call_service": {
-            "name": "API Call",
-            "description": "Perform a general API call to Clash and optionally retrieve response.",
-            "fields": {
-                "device_id": {
-                    "name": "Instance",
-                    "description": "Select the target instance"
-                },
-                "api_endpoint": {
-                    "name": "Endpoint",
-                    "description": "The API endpoint to be used"
-                },
-                "api_method": {
-                    "name": "Method",
-                    "description": "The HTTP method (GET, POST, etc.)"
-                },
-                "api_params": {
-                    "name": "Parameters",
-                    "description": "The query parameters for the request. Needs to be a valid json string"
-                },
-                "api_data": {
-                    "name": "Payload",
-                    "description": "The json body sent in the request. Needs to be a valid json string"
-                },
-                "read_line": {
-                    "name": "Read Line",
-                    "description": "Indicates to read the n-th line for a chunked response"
-                }
-            }
-        } 
-    } 
+        "group": {
+          "name": "Group Name",
+          "description": "The proxy group name. Testing a group will also clear its fixed option if set"
+        },
+        "node": {
+          "name": "Node Name",
+          "description": "The proxy node name"
+        },
+        "url": {
+          "name": "URL",
+          "description": "The URL used to test the latency"
+        },
+        "timeout": {
+          "name": "Timeout",
+          "description": "Connection timeout in milliseconds"
+        }
+      }
+    },
+    "dns_query_service": {
+      "name": "DNS Query",
+      "description": "Perform a DNS query with Clash.",
+      "fields": {
+        "device_id": {
+          "name": "Instance",
+          "description": "Select the target instance"
+        },
+        "domain_name": {
+          "name": "Domain Name",
+          "description": "The domain name to query"
+        },
+        "record_type": {
+          "name": "Record Type",
+          "description": "The record type to query. Leave empty to get IPv4 (A) record"
+        }
+      }
+    },
+    "get_rule_service": {
+      "name": "Get Rule",
+      "description": "Get rules using keyword filters.",
+      "fields": {
+        "device_id": {
+          "name": "Instance",
+          "description": "Select the target instance"
+        },
+        "rule_type": {
+          "name": "Type",
+          "description": "The type of the rule"
+        },
+        "rule_payload": {
+          "name": "Payload",
+          "description": "The payload to match"
+        },
+        "rule_proxy": {
+          "name": "Proxy",
+          "description": "The proxy method used"
+        }
+      }
+    },
+    "api_call_service": {
+      "name": "API Call",
+      "description": "Perform a general API call to Clash and optionally retrieve response.",
+      "fields": {
+        "device_id": {
+          "name": "Instance",
+          "description": "Select the target instance"
+        },
+        "api_endpoint": {
+          "name": "Endpoint",
+          "description": "The API endpoint to be used"
+        },
+        "api_method": {
+          "name": "Method",
+          "description": "The HTTP method (GET, POST, etc.)"
+        },
+        "api_params": {
+          "name": "Parameters",
+          "description": "The query parameters for the request. Needs to be a valid json string"
+        },
+        "api_data": {
+          "name": "Payload",
+          "description": "The json body sent in the request. Needs to be a valid json string"
+        },
+        "read_line": {
+          "name": "Read Line",
+          "description": "Indicates to read the n-th line for a chunked response"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/clash_controller/translations/zh-Hans.json
+++ b/custom_components/clash_controller/translations/zh-Hans.json
@@ -1,251 +1,262 @@
 {
-    "title": "Clash 控制器",
-    "config": {
-        "step": {
-            "user": {
-                "title": "Clash 控制器设置",
-                "data": {
-                    "api_url": "API 地址",
-                    "bearer_token": "令牌",
-                    "use_ssl": "使用 HTTPS",
-                    "allow_unsafe": "允许不安全的 SSL 证书"
-                },
-                "description": "请输入您的 Clash 实例的 API 地址和令牌。例如：192.168.1.1:9090，clash.mydomain.com。如果地址是 IP，请确保其为静态地址。"
-            }
-        },        
-        "error": {
-            "cannot_connect": "无法连接到 API，请验证地址后重试。",
-            "invalid_token": "提供的 API 令牌无效，请检查后重试。",
-            "unknown": "发生意外错误，请稍后重试。",
-            "timed_out": "API 连接超时， Clash 是否在运行？"
+  "title": "Clash 控制器",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Clash 控制器设置",
+        "data": {
+          "api_url": "API 地址",
+          "bearer_token": "令牌",
+          "use_ssl": "使用 HTTPS",
+          "allow_unsafe": "允许不安全的 SSL 证书"
         },
-        "abort": {
-            "already_configured": "此位置的实例已添加，请使用配置按钮更新令牌并修改设置。"
+        "description": "请输入您的 Clash 实例的 API 地址和令牌。例如：192.168.1.1:9090，clash.mydomain.com。如果地址是 IP，请确保其为静态地址。"
+      },
+      "reconfigure": {
+        "title": "重新配置 Clash 连接",
+        "description": "请更新此 Clash 实例的连接设置或认证凭据。",
+        "data": {
+          "api_url": "API 地址",
+          "bearer_token": "令牌",
+          "use_ssl": "使用 HTTPS",
+          "allow_unsafe": "允许不安全的 SSL 证书"
         }
+      }
     },
-    "options": {
-        "step": {
-            "init": {
-                "description": "修改此条目的选项。检测流媒体服务可用性时，Home Assistant 必须通过同一代理进行连接。",
-                "title": "Clash 控制器选项",
-                "data": {
-                    "scan_interval": "扫描间隔（秒）",
-                    "concurrent_connections": "并发连接数",
-                    "bearer_token": "更新令牌（留空则跳过）",
-                    "streaming_detection": "流媒体可用性检测"
-                }
-            }
-        },        
-        "error": {
-            "invalid_token": "提供的 API 令牌无效，请检查后重试。"
-        }
+    "error": {
+      "cannot_connect": "无法连接到 API，请验证地址后重试。",
+      "invalid_token": "提供的 API 令牌无效，请检查后重试。",
+      "unknown": "发生意外错误，请稍后重试。",
+      "timed_out": "API 连接超时， Clash 是否在运行？"
     },
-    "device": {
-        "clash_instance": {
-            "name": "Clash 实例"
-        }
-    },
-    "entity": {
-        "button":{
-          "flush_cache": {
-            "name": "清除 FakeIP 缓存"
-          },
-          "flush_dns_cache": {
-            "name": "清除 DNS 缓存"
-          },
-          "provider_healthcheck": {
-            "name": "{provider_name} 测速"
-          },
-          "default_proxy_group_healthcheck": {
-            "name": "默认代理组测速"
-          }
-        },
-        "select": {
-          "core_mode": {
-            "name": "代理模式",
-            "state": {
-                "rule": "规则",
-                "global": "全局",
-                "direct": "直连",
-                "script": "脚本"
-            }
-          }
-        },
-        "sensor": {
-          "up_speed": {
-            "name": "上传速度"
-          },
-          "down_speed": {
-            "name": "下载速度"
-          },
-          "up_traffic": {
-            "name": "上传流量"
-          },
-          "down_traffic": {
-            "name": "下载流量"
-          },
-          "memory_used": {
-            "name": "内存占用"
-          },
-          "connection_number": {
-            "name": "连接数"
-          },
-          "proxy_provider_count": {
-            "name": "代理集合数量"
-          },
-          "rule_provider_count": {
-            "name": "规则集合数量"
-          },
-          "netflix_service": {
-            "name": "Netflix",
-            "state":{
-                "unlocked": "已解锁",
-                "blocked": "未解锁",
-                "original_only": "仅限原创"
-            },
-            "state_attributes":{
-                "latency": {
-                    "name": "延迟"
-                },
-                "status_code": {
-                    "name": "状态码"
-                }
-            }
-          }
-        }
-    },
-    "services": {
-        "reboot_core_service": {
-            "name": "重启 Clash 核心",
-            "description": "重启远程 Clash 实例的核心。",
-            "fields": {
-                "device_id": {
-                    "name": "实例",
-                    "description": "选择目标实例"
-                }
-            }
-        },
-        "filter_connection_service": {
-            "name": "筛选连接",
-            "description": "使用关键字筛选活动连接，并可选择关闭连接。多个关键字请用逗号 \",\" 分隔。关键字不区分大小写。",
-            "fields": {
-                "device_id": {
-                    "name": "实例",
-                    "description": "选择目标实例"
-                },
-                "close_connection": {
-                    "name": "关闭连接",
-                    "description": "如果启用，筛选出的连接将被关闭"
-                },
-                "host": {
-                    "name": "主机",
-                    "description": "按主机筛选"
-                },
-                "src_hostname": {
-                    "name": "源 IP",
-                    "description": "按源 IP 筛选"
-                },
-                "des_hostname": {
-                    "name": "目标 IP",
-                    "description": "按目标 IP 筛选"
-                }
-            }
-        },
-        "get_latency_service": {
-            "name": "获取延迟",
-            "description": "获取指定节点或组的延迟，每次只能提供一个字段。如果 URL 配置错误或请求超时，可能会返回 504 错误。",
-            "fields": {
-                "device_id": {
-                    "name": "实例",
-                    "description": "选择目标实例"
-                },
-                "group": {
-                    "name": "策略组名称",
-                    "description": "策略组名称，获取策略组延迟将清除固定选项"
-                },
-                "node": {
-                    "name": "节点名称",
-                    "description": "代理节点名称"
-                },
-                "url": {
-                    "name": "URL",
-                    "description": "用于测试延迟的 URL"
-                },
-                "timeout": {
-                    "name": "超时时间",
-                    "description": "连接超时时间（毫秒）"
-                }
-            }
-        },
-        "dns_query_service": {
-            "name": "DNS 查询",
-            "description": "使用 Clash 进行 DNS 查询。",
-            "fields": {
-                "device_id": {
-                    "name": "实例",
-                    "description": "选择目标实例"
-                },
-                "domain_name": {
-                    "name": "域名",
-                    "description": "要查询的域名"
-                },
-                "record_type": {
-                    "name": "记录类型",
-                    "description": "要查询的记录类型，留空将获取 IPv4 (A) 记录"
-                }
-            }
-        },
-        "get_rule_service": {
-            "name": "获取规则",
-            "description": "使用关键字筛选规则。",
-            "fields": {
-                "device_id": {
-                    "name": "实例",
-                    "description": "选择目标实例"
-                },
-                "rule_type": {
-                    "name": "类型",
-                    "description": "规则的类型"
-                },
-                "rule_payload": {
-                    "name": "匹配内容",
-                    "description": "用于匹配的内容"
-                },
-                "rule_proxy": {
-                    "name": "代理方式",
-                    "description": "使用的代理方式"
-                }
-            }
-        },
-        "api_call_service": {
-            "name": "API 调用",
-            "description": "执行对 Clash 的通用 API 调用，并可选择性地获取响应。",
-            "fields": {
-                "device_id": {
-                    "name": "实例",
-                    "description": "选择目标实例"
-                },
-                "api_endpoint": {
-                    "name": "接口",
-                    "description": "要使用的 API 接口"
-                },
-                "api_method": {
-                    "name": "请求方法",
-                    "description": "HTTP 请求方法（GET、POST 等）"
-                },
-                "api_params": {
-                    "name": "请求参数",
-                    "description": "请求的查询参数，必须是有效的 JSON 字符串"
-                },
-                "api_data": {
-                    "name": "载荷",
-                    "description": "请求发送的 JSON 载荷，必须是有效的 JSON 字符串"
-                },
-                "read_line": {
-                    "name": "读取行",
-                    "description": "指示在分块响应中读取第 N 行"
-                }
-            }
-        }        
+    "abort": {
+      "already_configured": "此位置的实例已添加，请使用配置按钮更新令牌并修改设置。",
+      "reconfigure_successful": "重新配置成功。"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "修改此条目的选项。检测流媒体服务可用性时，Home Assistant 必须通过同一代理进行连接。",
+        "title": "Clash 控制器选项",
+        "data": {
+          "scan_interval": "扫描间隔（秒）",
+          "concurrent_connections": "并发连接数",
+          "bearer_token": "更新令牌（留空则跳过）",
+          "streaming_detection": "流媒体可用性检测"
+        }
+      }
+    },
+    "error": {
+      "invalid_token": "提供的 API 令牌无效，请检查后重试。"
+    }
+  },
+  "device": {
+    "clash_instance": {
+      "name": "Clash 实例"
+    }
+  },
+  "entity": {
+    "button": {
+      "flush_cache": {
+        "name": "清除 FakeIP 缓存"
+      },
+      "flush_dns_cache": {
+        "name": "清除 DNS 缓存"
+      },
+      "provider_healthcheck": {
+        "name": "{provider_name} 测速"
+      },
+      "default_proxy_group_healthcheck": {
+        "name": "默认代理组测速"
+      }
+    },
+    "select": {
+      "core_mode": {
+        "name": "代理模式",
+        "state": {
+          "rule": "规则",
+          "global": "全局",
+          "direct": "直连",
+          "script": "脚本"
+        }
+      }
+    },
+    "sensor": {
+      "up_speed": {
+        "name": "上传速度"
+      },
+      "down_speed": {
+        "name": "下载速度"
+      },
+      "up_traffic": {
+        "name": "上传流量"
+      },
+      "down_traffic": {
+        "name": "下载流量"
+      },
+      "memory_used": {
+        "name": "内存占用"
+      },
+      "connection_number": {
+        "name": "连接数"
+      },
+      "proxy_provider_count": {
+        "name": "代理集合数量"
+      },
+      "rule_provider_count": {
+        "name": "规则集合数量"
+      },
+      "netflix_service": {
+        "name": "Netflix",
+        "state": {
+          "unlocked": "已解锁",
+          "blocked": "未解锁",
+          "original_only": "仅限原创"
+        },
+        "state_attributes": {
+          "latency": {
+            "name": "延迟"
+          },
+          "status_code": {
+            "name": "状态码"
+          }
+        }
+      }
+    }
+  },
+  "services": {
+    "reboot_core_service": {
+      "name": "重启 Clash 核心",
+      "description": "重启远程 Clash 实例的核心。",
+      "fields": {
+        "device_id": {
+          "name": "实例",
+          "description": "选择目标实例"
+        }
+      }
+    },
+    "filter_connection_service": {
+      "name": "筛选连接",
+      "description": "使用关键字筛选活动连接，并可选择关闭连接。多个关键字请用逗号 \",\" 分隔。关键字不区分大小写。",
+      "fields": {
+        "device_id": {
+          "name": "实例",
+          "description": "选择目标实例"
+        },
+        "close_connection": {
+          "name": "关闭连接",
+          "description": "如果启用，筛选出的连接将被关闭"
+        },
+        "host": {
+          "name": "主机",
+          "description": "按主机筛选"
+        },
+        "src_hostname": {
+          "name": "源 IP",
+          "description": "按源 IP 筛选"
+        },
+        "des_hostname": {
+          "name": "目标 IP",
+          "description": "按目标 IP 筛选"
+        }
+      }
+    },
+    "get_latency_service": {
+      "name": "获取延迟",
+      "description": "获取指定节点或组的延迟，每次只能提供一个字段。如果 URL 配置错误或请求超时，可能会返回 504 错误。",
+      "fields": {
+        "device_id": {
+          "name": "实例",
+          "description": "选择目标实例"
+        },
+        "group": {
+          "name": "策略组名称",
+          "description": "策略组名称，获取策略组延迟将清除固定选项"
+        },
+        "node": {
+          "name": "节点名称",
+          "description": "代理节点名称"
+        },
+        "url": {
+          "name": "URL",
+          "description": "用于测试延迟的 URL"
+        },
+        "timeout": {
+          "name": "超时时间",
+          "description": "连接超时时间（毫秒）"
+        }
+      }
+    },
+    "dns_query_service": {
+      "name": "DNS 查询",
+      "description": "使用 Clash 进行 DNS 查询。",
+      "fields": {
+        "device_id": {
+          "name": "实例",
+          "description": "选择目标实例"
+        },
+        "domain_name": {
+          "name": "域名",
+          "description": "要查询的域名"
+        },
+        "record_type": {
+          "name": "记录类型",
+          "description": "要查询的记录类型，留空将获取 IPv4 (A) 记录"
+        }
+      }
+    },
+    "get_rule_service": {
+      "name": "获取规则",
+      "description": "使用关键字筛选规则。",
+      "fields": {
+        "device_id": {
+          "name": "实例",
+          "description": "选择目标实例"
+        },
+        "rule_type": {
+          "name": "类型",
+          "description": "规则的类型"
+        },
+        "rule_payload": {
+          "name": "匹配内容",
+          "description": "用于匹配的内容"
+        },
+        "rule_proxy": {
+          "name": "代理方式",
+          "description": "使用的代理方式"
+        }
+      }
+    },
+    "api_call_service": {
+      "name": "API 调用",
+      "description": "执行对 Clash 的通用 API 调用，并可选择性地获取响应。",
+      "fields": {
+        "device_id": {
+          "name": "实例",
+          "description": "选择目标实例"
+        },
+        "api_endpoint": {
+          "name": "接口",
+          "description": "要使用的 API 接口"
+        },
+        "api_method": {
+          "name": "请求方法",
+          "description": "HTTP 请求方法（GET、POST 等）"
+        },
+        "api_params": {
+          "name": "请求参数",
+          "description": "请求的查询参数，必须是有效的 JSON 字符串"
+        },
+        "api_data": {
+          "name": "载荷",
+          "description": "请求发送的 JSON 载荷，必须是有效的 JSON 字符串"
+        },
+        "read_line": {
+          "name": "读取行",
+          "description": "指示在分块响应中读取第 N 行"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
### 目的

为该集成添加 **“重新配置”** 支持。

### 变更

本 PR 在保持现有集成核心逻辑的前提下，引入了多项符合 Home Assistant 2026.x 标准的现代化改进：

#### 稳定的 Unique ID：  
- 实体现在基于 entry.entry_id（UUID）进行绑定。
- 当 API URL 或设备 IP 发生变化时，不再重复创建实体。

#### Reconfigure 支持：  
- 用户现在可以通过“重新配置（Reconfigure）”菜单更新 API URL 或 Token。
- 无需删除并重新添加集成。

#### 运行时数据迁移：  
- 数据存储从 hass.data 迁移至现代的 config_entry.runtime_data 。
- 提升性能、类型安全性，并符合 2026.x 架构规范。

#### 单位转换与统计：  
- 标准化了 device_class 与 state_class。
- 支持原生单位切换与 UI 中的长期统计曲线。

#### 架构说明：  
- 为保持与现有设计一致，目前仍由 Coordinator 驱动元数据（图标、翻译键）。
- 建议未来迁移至 Platform Descriptions，以进一步简化架构。

### 理由

为了支持 重新配置（Reconfigure），集成必须具备 稳定的 Unique ID。
因此本次更新对 Unique ID 的实现进行了重构，并同步完善了相关的运行时数据结构。

### 破坏性变更（Breaking Change）

- 由于本次更新包含破坏性变更，旧版本的配置无法自动兼容。
- 用户在升级后需要删除并重新添加该集成。
- 这是一次破坏性变更。

### 测试情况

- Reconfigure 流程可正确更新 API URL 与 Token。
- URL/IP 变化时实体不会重复创建，unique_id 保持稳定。
- 新安装与旧版本升级路径均正常工作。
- 单位切换与长期统计曲线在 UI 中正常显示。
- 多平台（如 sensor、binary_sensor）在同一 config entry 下均正常运行。

HA 测试版本：HA 2026.6.3

### 说明

为区别版本，该版本以提升至 0.3.0 。