### PR TITLE
test: enable sockets for module-scoped core fixture

### DIFF
--- a/tests/core_compatibility/conftest.py
+++ b/tests/core_compatibility/conftest.py
@@ -13,6 +13,12 @@ from .test_live_core import RunningCore
 from .test_live_core import running_core
 
 
+@pytest.fixture(autouse=True)
+def enable_real_core_sockets(socket_enabled: None) -> Iterator[None]:
+    """Enable sockets after Home Assistant's per-test socket guard runs."""
+    yield
+
+
 @pytest.fixture
 def hanging_api_url() -> Iterator[str]:
     """Expose a controller URL which accepts requests but never responds."""

--- a/tests/core_compatibility/test_live_core.py
+++ b/tests/core_compatibility/test_live_core.py
@@ -16,6 +16,7 @@ from urllib.parse import quote
 from urllib.request import Request, urlopen
 
 import pytest
+import pytest_socket
 import yaml
 
 API_PATH = (
@@ -179,6 +180,7 @@ def create_running_core(
 @pytest.fixture(scope="module")
 def running_core(tmp_path_factory: pytest.TempPathFactory) -> Iterator[RunningCore]:
     """Start the core selected by the CI matrix or local environment."""
+    pytest_socket.enable_socket()
     binary_value = os.environ.get("CLASH_CORE_BINARY")
     if not binary_value:
         pytest.skip("Set CLASH_CORE_BINARY to run real-core compatibility tests")


### PR DESCRIPTION
## Summary

- Enable sockets before the module-scoped real-core fixture allocates ports.
- Keep the per-test socket fixture for Home Assistant integration requests.

## Validation

- python tests/run.py system --all-cores
- Clash, Clash Premium, Clash.Meta: 8 passed, 1 skipped each
- Mihomo: 9 passed

This PR is intentionally left unmerged pending CI validation.